### PR TITLE
feat(depth_fusion): server-side port of matthew's reconstruction (worldscan-v2.3)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -33,6 +33,11 @@ dependencies = [
     "torch>=2.2",
     "scipy>=1.11",
 
+    # depth_fusion backend (worldscan-v2.3-depth-fusion)
+    "transformers>=4.40",
+    "torchvision>=0.17",
+    "onnxruntime>=1.20",
+
     # observability
     "sentry-sdk[fastapi]>=2.18",
 

--- a/backend/src/features/reconstruction/backends/_geometry.py
+++ b/backend/src/features/reconstruction/backends/_geometry.py
@@ -1,0 +1,198 @@
+"""Pure geometry helpers for the depth-fusion reconstruction backend.
+
+All functions are NumPy-only and pure. They mirror the math in matthew's
+browser-side pipeline (`prototype/v4.html`) so the server-side port produces
+equivalent reconstructions. Kept separate from depth_fusion.py for unit
+testability — no model loads, no I/O.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+def robust_linear_fit(z_ref: np.ndarray, z_new: np.ndarray) -> tuple[float, float]:
+    """Robust linear fit z_ref ≈ k * z_new + c on matched keypoint depths.
+
+    Even with metric depth, per-image monocular depth has scale/offset drift;
+    this corrects new-image depths into the reference frame before pose
+    alignment. Uses Theil–Sen (median of pairwise slopes) — unbiased when an
+    offset is present, robust to outliers. `k` is clamped to [0.5, 2.0]
+    (matthew's heuristic against ill-conditioned matches).
+    """
+    from scipy import stats  # local: scipy import is heavyish for module load
+
+    z_ref = np.asarray(z_ref, dtype=np.float64).ravel()
+    z_new = np.asarray(z_new, dtype=np.float64).ravel()
+    mask = (z_ref > 0.0) & (z_new > 0.0)
+    if mask.sum() < 4:
+        return 1.0, 0.0
+    zr, zn = z_ref[mask], z_new[mask]
+    slope, intercept, _lo, _hi = stats.theilslopes(zr, zn)
+    k = float(np.clip(slope, 0.5, 2.0))
+    c = float(intercept)
+    return k, c
+
+
+def umeyama_rigid(pts_a: np.ndarray, pts_b: np.ndarray) -> np.ndarray:
+    """Best rigid (rotation + translation, scale fixed to 1) transform mapping
+    `pts_a` to `pts_b`. Returns a 4x4 homogeneous matrix.
+
+    Uses the Umeyama SVD solution. Forcing scale=1 is correct when both point
+    sets are in metric units (Depth-Anything-V2-Metric); allowing the SVD's
+    natural scale on tight keypoint clusters collapses photos into a doll
+    house, per matthew's notes.
+    """
+    a = np.asarray(pts_a, dtype=np.float64)
+    b = np.asarray(pts_b, dtype=np.float64)
+    if a.shape != b.shape or a.shape[1] != 3 or a.shape[0] < 3:
+        raise ValueError(f"need ≥3 paired 3D points, got {a.shape} and {b.shape}")
+    mu_a, mu_b = a.mean(axis=0), b.mean(axis=0)
+    aa, bb = a - mu_a, b - mu_b
+    H = aa.T @ bb / aa.shape[0]
+    U, _, Vt = np.linalg.svd(H)
+    # Reflection fix: ensure right-handed rotation.
+    d = np.sign(np.linalg.det(U @ Vt))
+    S = np.diag([1.0, 1.0, d])
+    R = (U @ S @ Vt).T
+    t = mu_b - R @ mu_a
+    T = np.eye(4, dtype=np.float64)
+    T[:3, :3] = R
+    T[:3, 3] = t
+    return T
+
+
+def ransac_umeyama(
+    pts_a: np.ndarray,
+    pts_b: np.ndarray,
+    iters: int = 200,
+    inlier_thresh_m: float = 0.15,
+    min_inliers: int = 10,
+    rng: np.random.Generator | None = None,
+) -> tuple[np.ndarray | None, np.ndarray]:
+    """RANSAC over rigid Umeyama. Returns (4x4 transform, inlier mask) or
+    (None, empty mask) if no consensus set reaches `min_inliers`.
+
+    Defaults match matthew's JS (200 iters, 0.15 m, ≥10 inliers).
+    """
+    rng = rng if rng is not None else np.random.default_rng(0)
+    a = np.asarray(pts_a, dtype=np.float64)
+    b = np.asarray(pts_b, dtype=np.float64)
+    n = a.shape[0]
+    if n < 3:
+        return None, np.zeros(n, dtype=bool)
+
+    best_inliers = np.zeros(n, dtype=bool)
+    best_T: np.ndarray | None = None
+    for _ in range(iters):
+        idx = rng.choice(n, size=3, replace=False)
+        try:
+            T = umeyama_rigid(a[idx], b[idx])
+        except (ValueError, np.linalg.LinAlgError):
+            continue
+        a_t = (T[:3, :3] @ a.T).T + T[:3, 3]
+        err = np.linalg.norm(a_t - b, axis=1)
+        inliers = err < inlier_thresh_m
+        if inliers.sum() > best_inliers.sum():
+            best_inliers = inliers
+            best_T = T
+
+    if best_inliers.sum() < min_inliers or best_T is None:
+        return None, np.zeros(n, dtype=bool)
+
+    # Refit on the full inlier set for a tighter transform.
+    refit = umeyama_rigid(a[best_inliers], b[best_inliers])
+    return refit, best_inliers
+
+
+def back_project(
+    depth: np.ndarray,
+    color: np.ndarray,
+    intrinsics: np.ndarray,
+    world_transform: np.ndarray | None = None,
+    discontinuity_m: float = 0.3,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Lift a depth grid to a colored triangle mesh.
+
+    Returns (vertices Nx3, faces Mx3, colors Nx3 uint8). Faces are skipped at
+    depth discontinuities (>= discontinuity_m between adjacent pixels) to
+    avoid stretched ghost geometry around object edges.
+
+    Coordinate convention: camera looks down +Z; X right, Y down (OpenCV).
+    `intrinsics` is a 3x3 K matrix. If `world_transform` (4x4) is given,
+    vertices are pre-multiplied into world frame.
+    """
+    if depth.ndim != 2:
+        raise ValueError(f"depth must be HxW, got {depth.shape}")
+    if color.ndim != 3 or color.shape[2] != 3:
+        raise ValueError(f"color must be HxWx3, got {color.shape}")
+    if color.shape[:2] != depth.shape:
+        raise ValueError(f"color {color.shape[:2]} != depth {depth.shape}")
+
+    H, W = depth.shape
+    fx, fy = intrinsics[0, 0], intrinsics[1, 1]
+    cx, cy = intrinsics[0, 2], intrinsics[1, 2]
+
+    us, vs = np.meshgrid(np.arange(W, dtype=np.float64), np.arange(H, dtype=np.float64))
+    z = depth.astype(np.float64)
+    x = (us - cx) * z / fx
+    y = (vs - cy) * z / fy
+
+    verts = np.stack([x.ravel(), y.ravel(), z.ravel()], axis=1)
+    cols = color.reshape(-1, 3).astype(np.uint8)
+
+    if world_transform is not None:
+        R = world_transform[:3, :3]
+        t = world_transform[:3, 3]
+        verts = (R @ verts.T).T + t
+
+    # Triangulate the depth grid. Two triangles per cell; skip both if any
+    # corner's depth is invalid or any edge crosses a discontinuity.
+    faces: list[np.ndarray] = []
+    idx = np.arange(H * W, dtype=np.int64).reshape(H, W)
+    z_grid = z  # alias for clarity
+    valid = z_grid > 0.0
+
+    i0 = idx[:-1, :-1].ravel()  # top-left
+    i1 = idx[:-1, 1:].ravel()   # top-right
+    i2 = idx[1:, :-1].ravel()   # bot-left
+    i3 = idx[1:, 1:].ravel()    # bot-right
+
+    z0 = z_grid[:-1, :-1].ravel()
+    z1 = z_grid[:-1, 1:].ravel()
+    z2 = z_grid[1:, :-1].ravel()
+    z3 = z_grid[1:, 1:].ravel()
+
+    v0 = valid[:-1, :-1].ravel()
+    v1 = valid[:-1, 1:].ravel()
+    v2 = valid[1:, :-1].ravel()
+    v3 = valid[1:, 1:].ravel()
+
+    span = np.maximum.reduce([
+        np.abs(z0 - z1), np.abs(z0 - z2), np.abs(z0 - z3),
+        np.abs(z1 - z2), np.abs(z1 - z3), np.abs(z2 - z3),
+    ])
+    ok = v0 & v1 & v2 & v3 & (span < discontinuity_m)
+
+    faces.append(np.stack([i0[ok], i2[ok], i1[ok]], axis=1))
+    faces.append(np.stack([i1[ok], i2[ok], i3[ok]], axis=1))
+    faces_arr = np.concatenate(faces, axis=0) if faces else np.zeros((0, 3), dtype=np.int64)
+
+    return verts.astype(np.float32), faces_arr.astype(np.int64), cols
+
+
+def assume_intrinsics(width: int, height: int, fov_deg: float = 60.0) -> np.ndarray:
+    """Build a 3x3 K matrix from image size + horizontal FOV (degrees).
+
+    Used when `ReconstructionInput.intrinsics_hint` is None — picks a sensible
+    default that matches matthew's prototype assumptions (~60° hFOV, principal
+    point at image center).
+    """
+    fx = width / (2.0 * np.tan(np.radians(fov_deg) / 2.0))
+    fy = fx  # assume square pixels
+    cx = width / 2.0
+    cy = height / 2.0
+    K = np.array(
+        [[fx, 0.0, cx], [0.0, fy, cy], [0.0, 0.0, 1.0]],
+        dtype=np.float64,
+    )
+    return K

--- a/backend/src/features/reconstruction/backends/_models.py
+++ b/backend/src/features/reconstruction/backends/_models.py
@@ -1,0 +1,204 @@
+"""Model loaders + inference for depth-fusion. Lazy, process-cached.
+
+Depth uses transformers (Depth-Anything-V2-Metric-Indoor-Small by default,
+Apple Depth-Pro optional). Feature extraction + matching uses SuperPoint and
+LightGlue ONNX models, downloaded from the same URLs matthew's prototype
+uses so the legacy Flask server and the new backend share weights.
+"""
+from __future__ import annotations
+
+import subprocess
+import threading
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+# rl_env is a workspace member of the backend (see backend/pyproject.toml).
+# Imports of `rl_env.server` are deferred to call sites because that module
+# pulls in flask at import time, which is only needed for matthew's legacy
+# server, not for backend tests of pure-math helpers.
+
+# Process-wide caches (matches matthew's `_depth_cache` pattern). Guarded by
+# locks so concurrent Inngest workers don't double-load.
+_depth_lock = threading.Lock()
+_onnx_lock = threading.Lock()
+_onnx_sessions: dict[str, "object"] = {}
+
+
+def get_depth_model(name: str = "indoor"):
+    """Return matthew's lazily-loaded depth pipeline (`indoor` or `pro`).
+
+    Wraps `rl_env.server._ensure_depth_model` so the legacy Flask `/api/depth`
+    endpoint and this backend share the same in-memory weights.
+    """
+    from rl_env.server import _ensure_depth_model  # type: ignore[attr-defined]
+    with _depth_lock:
+        return _ensure_depth_model(name)
+
+
+def infer_depth(image: Image.Image, name: str = "indoor") -> tuple[np.ndarray, dict]:
+    """Run depth inference on a PIL image; return (depth_meters HxW float32, meta).
+
+    Meta carries the model name, output shape, and optional FOV (Depth-Pro only).
+    Mirrors matthew's `rl_env.server.api_depth` handling so outputs match the
+    legacy Flask endpoint exactly.
+    """
+    handle = get_depth_model(name)
+    meta: dict = {"depth_model": name}
+    if handle["kind"] == "pipeline":
+        out = handle["pipe"](image)
+        pred = out["predicted_depth"]
+        depth = pred.detach().cpu().numpy() if hasattr(pred, "detach") else np.asarray(pred)
+    elif handle["kind"] == "explicit":
+        import torch  # local: torch is in pyproject but defer importing it
+        proc = handle["proc"]
+        model = handle["model"]
+        device = handle["device"]
+        inputs = proc(images=image, return_tensors="pt").to(device)
+        with torch.inference_mode():
+            outputs = model(**inputs)
+        post = proc.post_process_depth_estimation(
+            outputs, target_sizes=[(image.height, image.width)]
+        )[0]
+        depth = post["predicted_depth"].detach().cpu().numpy()
+        fov_value = post.get("field_of_view") or post.get("fov")
+        if fov_value is not None:
+            meta["fov_deg"] = float(fov_value.item() if hasattr(fov_value, "item") else fov_value)
+    else:
+        raise ValueError(f"unknown depth handle kind {handle.get('kind')!r}")
+
+    depth = np.asarray(depth, dtype=np.float32)
+    while depth.ndim > 2:
+        depth = depth.squeeze(0)
+    meta["depth_shape"] = list(depth.shape)
+    return depth, meta
+
+
+def _models_cache_dir() -> Path:
+    """Where ONNX model files live on disk. Mirrors matthew's location so
+    the Flask `/api/models/<name>` endpoint can also serve the cached files
+    without re-downloading.
+    """
+    # rl_env.server resolves ROOT relative to itself; we want the same root.
+    from rl_env.server import MODELS_CACHE_DIR  # type: ignore[attr-defined]
+    return Path(MODELS_CACHE_DIR)
+
+
+def _download_onnx(name: str) -> Path:
+    """Fetch `<name>.onnx` from MODEL_URLS into the shared cache dir if missing."""
+    from rl_env.server import MODEL_URLS  # type: ignore[attr-defined]
+    if name not in MODEL_URLS:
+        raise ValueError(f"unknown ONNX model {name!r}; known: {list(MODEL_URLS)}")
+    cache_dir = _models_cache_dir()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_path = cache_dir / f"{name}.onnx"
+    if cache_path.exists():
+        return cache_path
+    url = MODEL_URLS[name]
+    tmp_path = cache_path.with_suffix(".onnx.partial")
+    # curl avoids macOS Python's CA-bundle issue (matches matthew's approach).
+    subprocess.run(["curl", "-fsSL", "-o", str(tmp_path), url], check=True)
+    tmp_path.rename(cache_path)
+    return cache_path
+
+
+def _onnx_session(name: str):
+    """Lazy-load an onnxruntime InferenceSession, cached for the process."""
+    with _onnx_lock:
+        sess = _onnx_sessions.get(name)
+        if sess is not None:
+            return sess
+        import onnxruntime as ort
+        path = _download_onnx(name)
+        # CPU works everywhere; CUDA EP is preferred when available.
+        providers = ["CPUExecutionProvider"]
+        if "CUDAExecutionProvider" in ort.get_available_providers():
+            providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+        sess = ort.InferenceSession(str(path), providers=providers)
+        _onnx_sessions[name] = sess
+        return sess
+
+
+def _preprocess_for_superpoint(image: Image.Image, max_side: int = 512) -> tuple[np.ndarray, float]:
+    """Grayscale + resize-down to keep the longer side ≤ max_side. Returns
+    (image_array float32 0-1, scale_factor) so detected keypoints can be
+    mapped back to original coordinates.
+    """
+    w, h = image.size
+    scale = min(1.0, float(max_side) / float(max(w, h)))
+    if scale < 1.0:
+        new_w, new_h = int(round(w * scale)), int(round(h * scale))
+        image = image.resize((new_w, new_h), Image.BILINEAR)
+    gray = image.convert("L")
+    arr = np.asarray(gray, dtype=np.float32) / 255.0
+    # SuperPoint expects (1, 1, H, W).
+    arr = arr[None, None, :, :]
+    return arr, scale
+
+
+def extract_superpoint(image: Image.Image, max_keypoints: int = 1024) -> dict:
+    """Run SuperPoint ONNX on a PIL image. Returns
+        {"keypoints": (N,2) in ORIGINAL image coords, "descriptors": (N,256), "scores": (N,)}.
+
+    Caps to top-`max_keypoints` by score, matching matthew's heuristic.
+    """
+    sess = _onnx_session("superpoint")
+    arr, scale = _preprocess_for_superpoint(image)
+    inputs = {sess.get_inputs()[0].name: arr}
+    out_names = [o.name for o in sess.get_outputs()]
+    outs = sess.run(out_names, inputs)
+    # ONNX SuperPoint export from fabio-sim/LightGlue-ONNX returns
+    # (keypoints[1,N,2], scores[1,N], descriptors[1,N,256]).
+    kp = outs[0][0]
+    scores = outs[1][0]
+    desc = outs[2][0]
+    if kp.shape[0] > max_keypoints:
+        top = np.argsort(scores)[-max_keypoints:]
+        kp, scores, desc = kp[top], scores[top], desc[top]
+    if scale < 1.0:
+        kp = kp.astype(np.float32) / scale
+    return {"keypoints": kp.astype(np.float32), "descriptors": desc.astype(np.float32), "scores": scores.astype(np.float32)}
+
+
+def match_lightglue(feat_a: dict, feat_b: dict, image_size: tuple[int, int]) -> np.ndarray:
+    """Match two SuperPoint feature sets via LightGlue ONNX. Returns an (M, 2)
+    array of (idx_a, idx_b) matched indices into the original feature arrays.
+
+    `image_size` is (width, height) of the original images, used by LightGlue
+    to normalize keypoint coordinates.
+    """
+    sess = _onnx_session("superpoint_lightglue")
+    w, h = image_size
+    # Normalize keypoints to [-1, 1] as LightGlue expects (per fabio-sim ONNX
+    # contract).
+    def norm(kp: np.ndarray) -> np.ndarray:
+        kp = kp.astype(np.float32).copy()
+        kp[:, 0] = (kp[:, 0] - w / 2.0) / (max(w, h) / 2.0)
+        kp[:, 1] = (kp[:, 1] - h / 2.0) / (max(w, h) / 2.0)
+        return kp[None, ...]  # (1, N, 2)
+
+    inputs = {
+        "kpts0": norm(feat_a["keypoints"]),
+        "kpts1": norm(feat_b["keypoints"]),
+        "desc0": feat_a["descriptors"][None, ...],
+        "desc1": feat_b["descriptors"][None, ...],
+    }
+    # Filter to inputs the model actually accepts.
+    expected = {i.name for i in sess.get_inputs()}
+    inputs = {k: v for k, v in inputs.items() if k in expected}
+    out_names = [o.name for o in sess.get_outputs()]
+    outs = sess.run(out_names, inputs)
+    # The fabio-sim LightGlue ONNX exports `matches0` (1, M, 2) of (idx_a, idx_b).
+    matches = outs[0]
+    if matches.ndim == 3:
+        matches = matches[0]
+    return matches.astype(np.int64)
+
+
+__all__ = [
+    "get_depth_model",
+    "infer_depth",
+    "extract_superpoint",
+    "match_lightglue",
+]

--- a/backend/src/features/reconstruction/backends/depth_fusion.py
+++ b/backend/src/features/reconstruction/backends/depth_fusion.py
@@ -1,24 +1,107 @@
-"""Monocular depth + TSDF fusion backend stub.
-Planned for change `worldscan-v2.3-depth-fusion`.
+"""Depth-fusion reconstruction backend — server-side port of matthew's
+prototype/v4.html pipeline.
+
+Pipeline per frame:
+  1. Monocular metric depth (Depth-Anything-V2-Metric-Indoor by default).
+  2. SuperPoint keypoints + descriptors (ONNX).
+
+Cross-frame fusion (for each new frame i, find best previous frame j to fuse
+against):
+  3. LightGlue match (i, j); skip if < 8 matches.
+  4. Depth calibration: linear robust fit of frame i's depths onto frame j's,
+     correcting monocular drift before pose alignment.
+  5. Pose: RANSAC + rigid Umeyama on matched keypoint 3D points
+     (rigid=True since depth is metric — preserves world scale).
+  6. Compose into a per-frame back-projected colored mesh in world space.
+
+Outputs:
+  - mesh.ply: concatenated per-frame meshes (triangles, vertex colors)
+  - points.ply: same vertex cloud unindexed
+
+Reuses matthew's depth weights via `rl_env.server` so the legacy Flask
+`/api/depth` and this backend stay in sync.
 """
 from __future__ import annotations
 
+import logging
+import time
 from collections.abc import Callable
 from pathlib import Path
 
+import numpy as np
+import trimesh
+from PIL import Image
+
 from src.features.reconstruction.backends import register
+from src.features.reconstruction.backends._geometry import (
+    assume_intrinsics,
+    back_project,
+    ransac_umeyama,
+    robust_linear_fit,
+)
+from src.features.reconstruction.backends._models import (
+    extract_superpoint,
+    infer_depth,
+    match_lightglue,
+)
 from src.features.reconstruction.backends.base import (
     ReconstructionBackend,
     ReconstructionInput,
     ReconstructionOutput,
 )
 
+log = logging.getLogger(__name__)
+
+# Defaults match matthew's JS heuristics; tunable via ReconstructionInput.intrinsics_hint.
+_MIN_MATCHES = 8
+_GOOD_MATCHES = 500  # stop searching backward once a frame has this many matches
+_FOV_DEG_DEFAULT = 60.0
+_DISCONTINUITY_M = 0.30
+_RANSAC_ITERS = 200
+_RANSAC_THRESH_M = 0.15
+_RANSAC_MIN_INLIERS = 10
+
+
+def _sample_depth_at(depth: np.ndarray, kp: np.ndarray) -> np.ndarray:
+    """Sample depth at keypoint pixel coordinates with nearest-neighbor.
+    Returns 0 for out-of-bounds or invalid (≤0) samples so callers can mask."""
+    h, w = depth.shape
+    u = np.clip(np.round(kp[:, 0]).astype(np.int64), 0, w - 1)
+    v = np.clip(np.round(kp[:, 1]).astype(np.int64), 0, h - 1)
+    return depth[v, u]
+
+
+def _kp_to_camera_points(kp: np.ndarray, z: np.ndarray, K: np.ndarray) -> np.ndarray:
+    """Lift 2D keypoints + per-keypoint depth into camera-frame 3D points."""
+    fx, fy = K[0, 0], K[1, 1]
+    cx, cy = K[0, 2], K[1, 2]
+    X = (kp[:, 0] - cx) * z / fx
+    Y = (kp[:, 1] - cy) * z / fy
+    return np.stack([X, Y, z], axis=1)
+
+
+def _write_ply_mesh(verts: np.ndarray, faces: np.ndarray, colors: np.ndarray, path: Path) -> None:
+    mesh = trimesh.Trimesh(
+        vertices=verts.astype(np.float64),
+        faces=faces.astype(np.int64),
+        vertex_colors=colors.astype(np.uint8),
+        process=False,
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    mesh.export(path)
+
+
+def _write_ply_points(verts: np.ndarray, colors: np.ndarray, path: Path) -> None:
+    cloud = trimesh.points.PointCloud(verts.astype(np.float64), colors=colors.astype(np.uint8))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cloud.export(path)
+
 
 @register
 class DepthFusionBackend(ReconstructionBackend):
     name = "depth_fusion"
     requires_gpu = True
-    implemented = False
+    implemented = True
 
     def reconstruct(
         self,
@@ -26,4 +109,161 @@ class DepthFusionBackend(ReconstructionBackend):
         out_dir: Path,
         progress_cb: Callable[[float, str], None],
     ) -> ReconstructionOutput:
-        raise NotImplementedError("planned: worldscan-v2.3-depth-fusion")
+        frames_dir = inp.frames_dir
+        frame_paths = sorted([p for p in frames_dir.iterdir() if p.suffix.lower() in {".jpg", ".jpeg", ".png"}])
+        if not frame_paths:
+            raise RuntimeError(f"no frames found under {frames_dir}")
+
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        depth_model = (inp.intrinsics_hint or {}).get("depth_model", "indoor")
+        fov_deg = float((inp.intrinsics_hint or {}).get("fov_deg", _FOV_DEG_DEFAULT))
+
+        per_frame: list[dict] = []
+        all_verts: list[np.ndarray] = []
+        all_faces: list[np.ndarray] = []
+        all_colors: list[np.ndarray] = []
+        vertex_offset = 0
+        n_fused = 0
+        n_failed_fusion = 0
+        inlier_counts: list[int] = []
+
+        log.info("[depth_fusion] %d frames, depth=%s, fov=%.1f°", len(frame_paths), depth_model, fov_deg)
+
+        for i, fp in enumerate(frame_paths):
+            t_frame = time.time()
+            img = Image.open(fp).convert("RGB")
+            w, h = img.size
+            depth, _depth_meta = infer_depth(img, name=depth_model)
+            if depth.shape != (h, w):
+                # Resize depth onto the image grid if the model emitted a different size.
+                depth = np.asarray(
+                    Image.fromarray(depth).resize((w, h), Image.BILINEAR),
+                    dtype=np.float32,
+                )
+            feat = extract_superpoint(img)
+            K = assume_intrinsics(w, h, fov_deg=fov_deg)
+
+            world_T = np.eye(4, dtype=np.float64)  # frame 0 anchors world at identity
+            if i > 0:
+                # Search backward for the best previously-fused frame to fuse onto.
+                best_j: int | None = None
+                best_matches: np.ndarray | None = None
+                for j in range(i - 1, -1, -1):
+                    matches = match_lightglue(per_frame[j]["feat"], feat, image_size=(w, h))
+                    if matches.shape[0] < _MIN_MATCHES:
+                        continue
+                    if best_matches is None or matches.shape[0] > best_matches.shape[0]:
+                        best_matches = matches
+                        best_j = j
+                    if matches.shape[0] >= _GOOD_MATCHES:
+                        break
+
+                if best_j is None or best_matches is None:
+                    log.warning("[depth_fusion] frame %d: <%d matches against any previous; placing offset", i, _MIN_MATCHES)
+                    world_T[:3, 3] = np.array([0.0, 0.0, 1.0 * i])  # naive lateral offset
+                    n_failed_fusion += 1
+                else:
+                    ref = per_frame[best_j]
+                    idx_j, idx_i = best_matches[:, 0], best_matches[:, 1]
+                    kp_j = ref["feat"]["keypoints"][idx_j]
+                    kp_i = feat["keypoints"][idx_i]
+                    z_j_at_kp = _sample_depth_at(ref["depth"], kp_j)
+                    z_i_at_kp = _sample_depth_at(depth, kp_i)
+
+                    # Depth calibration: rescale frame i's depths into frame j's frame.
+                    k_scale, c_off = robust_linear_fit(z_j_at_kp, z_i_at_kp)
+                    depth = np.clip(k_scale * depth + c_off, 0.0, None)
+                    z_i_at_kp = k_scale * z_i_at_kp + c_off
+
+                    # Build paired 3D points: frame j in world, frame i in camera_i.
+                    pts_i = _kp_to_camera_points(kp_i, z_i_at_kp, K)
+                    pts_j_cam = _kp_to_camera_points(kp_j, z_j_at_kp, K)
+                    pts_j_world = (ref["world_T"][:3, :3] @ pts_j_cam.T).T + ref["world_T"][:3, 3]
+
+                    # Mask invalid depths (≤0 at keypoints).
+                    valid = (z_i_at_kp > 0) & (z_j_at_kp > 0)
+                    if valid.sum() < _RANSAC_MIN_INLIERS:
+                        log.warning(
+                            "[depth_fusion] frame %d → %d: only %d valid matched depths; offset fallback",
+                            i, best_j, int(valid.sum()),
+                        )
+                        world_T = ref["world_T"].copy()
+                        world_T[:3, 3] = world_T[:3, 3] + np.array([0.3, 0.0, 0.0])
+                        n_failed_fusion += 1
+                    else:
+                        T, inliers = ransac_umeyama(
+                            pts_i[valid], pts_j_world[valid],
+                            iters=_RANSAC_ITERS, inlier_thresh_m=_RANSAC_THRESH_M, min_inliers=_RANSAC_MIN_INLIERS,
+                        )
+                        if T is None:
+                            log.warning(
+                                "[depth_fusion] frame %d → %d: RANSAC failed (%d valid pts); offset fallback",
+                                i, best_j, int(valid.sum()),
+                            )
+                            world_T = ref["world_T"].copy()
+                            world_T[:3, 3] = world_T[:3, 3] + np.array([0.3, 0.0, 0.0])
+                            n_failed_fusion += 1
+                        else:
+                            world_T = T
+                            n_fused += 1
+                            inlier_counts.append(int(inliers.sum()))
+                            log.info(
+                                "[depth_fusion] frame %d → ref %d: %d matches, %d inliers, k=%.3f c=%.3f",
+                                i, best_j, best_matches.shape[0], int(inliers.sum()), k_scale, c_off,
+                            )
+
+            # Back-project this frame into world space and collect its mesh.
+            verts, faces, colors = back_project(
+                depth=depth,
+                color=np.asarray(img),
+                intrinsics=K,
+                world_transform=world_T,
+                discontinuity_m=_DISCONTINUITY_M,
+            )
+            if faces.shape[0] > 0:
+                all_verts.append(verts)
+                all_colors.append(colors)
+                all_faces.append(faces + vertex_offset)
+                vertex_offset += verts.shape[0]
+
+            per_frame.append({
+                "feat": feat,
+                "depth": depth,
+                "world_T": world_T,
+            })
+
+            elapsed = time.time() - t_frame
+            log.info("[depth_fusion] frame %d/%d done in %.2fs (%d verts)", i + 1, len(frame_paths), elapsed, verts.shape[0])
+            progress_cb((i + 1) / len(frame_paths), f"frame {i + 1}/{len(frame_paths)}")
+
+        if not all_verts:
+            raise RuntimeError("depth_fusion produced no geometry — every frame failed back-projection")
+
+        verts = np.concatenate(all_verts, axis=0)
+        colors = np.concatenate(all_colors, axis=0)
+        faces = np.concatenate(all_faces, axis=0)
+
+        mesh_path = out_dir / "mesh.ply"
+        points_path = out_dir / "points.ply"
+        _write_ply_mesh(verts, faces, colors, mesh_path)
+        _write_ply_points(verts, colors, points_path)
+
+        backend_meta = {
+            "depth_model": depth_model,
+            "fov_deg": fov_deg,
+            "n_frames": len(frame_paths),
+            "n_fused": n_fused,
+            "n_failed_fusion": n_failed_fusion,
+            "avg_inliers": float(np.mean(inlier_counts)) if inlier_counts else 0.0,
+            "vertices": int(verts.shape[0]),
+            "faces": int(faces.shape[0]),
+        }
+        log.info("[depth_fusion] done: %s", backend_meta)
+
+        return ReconstructionOutput(
+            mesh_path=mesh_path,
+            point_cloud_path=points_path,
+            camera_poses={f"frame_{i:04d}": f["world_T"].tolist() for i, f in enumerate(per_frame)},
+            backend_meta=backend_meta,
+        )

--- a/backend/tests/test_depth_fusion_geometry.py
+++ b/backend/tests/test_depth_fusion_geometry.py
@@ -1,0 +1,133 @@
+"""Unit tests for depth-fusion geometry helpers. Pure math, no GPU/models."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.features.reconstruction.backends._geometry import (
+    assume_intrinsics,
+    back_project,
+    ransac_umeyama,
+    robust_linear_fit,
+    umeyama_rigid,
+)
+
+
+def test_robust_linear_fit_recovers_scale_offset() -> None:
+    rng = np.random.default_rng(0)
+    z_new = rng.uniform(0.5, 5.0, size=50)
+    k_true, c_true = 1.3, 0.2
+    z_ref = k_true * z_new + c_true + rng.normal(0, 0.01, size=50)
+    k, c = robust_linear_fit(z_ref, z_new)
+    assert abs(k - k_true) < 0.05
+    assert abs(c - c_true) < 0.05
+
+
+def test_robust_linear_fit_survives_outliers() -> None:
+    rng = np.random.default_rng(1)
+    z_new = rng.uniform(0.5, 5.0, size=50)
+    z_ref = 1.1 * z_new + 0.05
+    # Corrupt 30% with wild outliers.
+    z_ref[::3] = rng.uniform(-10, 50, size=z_ref[::3].shape)
+    k, c = robust_linear_fit(z_ref, z_new)
+    assert 0.9 < k < 1.3
+    assert -1.0 < c < 1.0
+
+
+def test_robust_linear_fit_falls_back_when_too_few_points() -> None:
+    k, c = robust_linear_fit(np.array([1.0, 2.0]), np.array([0.5, 1.0]))
+    assert k == 1.0 and c == 0.0
+
+
+def test_umeyama_rigid_recovers_known_transform() -> None:
+    rng = np.random.default_rng(2)
+    pts = rng.normal(size=(20, 3))
+    theta = 0.5
+    R = np.array([
+        [np.cos(theta), -np.sin(theta), 0.0],
+        [np.sin(theta), np.cos(theta), 0.0],
+        [0.0, 0.0, 1.0],
+    ])
+    t = np.array([0.3, -0.7, 1.1])
+    pts_t = (R @ pts.T).T + t
+
+    T = umeyama_rigid(pts, pts_t)
+    R_est, t_est = T[:3, :3], T[:3, 3]
+    np.testing.assert_allclose(R_est, R, atol=1e-6)
+    np.testing.assert_allclose(t_est, t, atol=1e-6)
+    # Apply and check it round-trips.
+    pts_back = (R_est @ pts.T).T + t_est
+    np.testing.assert_allclose(pts_back, pts_t, atol=1e-6)
+
+
+def test_umeyama_rejects_degenerate_input() -> None:
+    with pytest.raises(ValueError):
+        umeyama_rigid(np.zeros((2, 3)), np.zeros((2, 3)))
+
+
+def test_ransac_umeyama_picks_inliers_around_outliers() -> None:
+    rng = np.random.default_rng(3)
+    pts = rng.normal(size=(60, 3))
+    theta = 0.4
+    R = np.array([
+        [np.cos(theta), -np.sin(theta), 0.0],
+        [np.sin(theta), np.cos(theta), 0.0],
+        [0.0, 0.0, 1.0],
+    ])
+    t = np.array([0.2, 0.5, -0.3])
+    pts_t = (R @ pts.T).T + t
+    # Corrupt 40% with random offsets.
+    bad = slice(0, 24)
+    pts_t[bad] = pts_t[bad] + rng.uniform(-5.0, 5.0, size=(24, 3))
+
+    T, inliers = ransac_umeyama(pts, pts_t, iters=300, inlier_thresh_m=0.1, min_inliers=10, rng=rng)
+    assert T is not None
+    # Inliers should be predominantly from the clean half (idx >= 24).
+    inlier_idxs = np.where(inliers)[0]
+    assert inliers.sum() >= 20
+    assert (inlier_idxs >= 24).mean() > 0.9
+
+
+def test_ransac_returns_none_when_no_consensus() -> None:
+    rng = np.random.default_rng(4)
+    pts = rng.normal(size=(20, 3))
+    noise = rng.uniform(-100, 100, size=(20, 3))
+    T, inliers = ransac_umeyama(pts, noise, iters=100, inlier_thresh_m=0.05, min_inliers=10, rng=rng)
+    assert T is None
+    assert inliers.sum() == 0
+
+
+def test_back_project_produces_mesh_for_simple_plane() -> None:
+    # 4x4 flat depth grid at z=1m.
+    depth = np.ones((4, 4), dtype=np.float32)
+    color = (np.ones((4, 4, 3)) * 255).astype(np.uint8)
+    K = assume_intrinsics(width=4, height=4, fov_deg=60.0)
+    verts, faces, cols = back_project(depth, color, K, world_transform=None, discontinuity_m=0.1)
+    assert verts.shape == (16, 3)
+    assert cols.shape == (16, 3)
+    # 3 cells x 3 cells x 2 triangles = 18 faces.
+    assert faces.shape == (18, 3)
+    # All z values are 1.
+    np.testing.assert_allclose(verts[:, 2], 1.0, atol=1e-6)
+
+
+def test_back_project_skips_discontinuities() -> None:
+    depth = np.ones((4, 4), dtype=np.float32)
+    depth[2:, :] = 5.0  # half the grid jumps 4 m away
+    color = (np.ones((4, 4, 3)) * 128).astype(np.uint8)
+    K = assume_intrinsics(width=4, height=4, fov_deg=60.0)
+    verts, faces, _ = back_project(depth, color, K, world_transform=None, discontinuity_m=0.5)
+    # Cells crossing the row-2 boundary get culled; only top and bottom 3-cell rows survive,
+    # so faces = (1 + 1) rows × 3 cols × 2 triangles = 12.
+    assert faces.shape[0] == 12
+
+
+def test_back_project_applies_world_transform() -> None:
+    depth = np.ones((2, 2), dtype=np.float32)
+    color = np.zeros((2, 2, 3), dtype=np.uint8)
+    K = assume_intrinsics(2, 2, fov_deg=60.0)
+    T = np.eye(4)
+    T[:3, 3] = [10.0, 20.0, 30.0]
+    verts, _, _ = back_project(depth, color, K, world_transform=T)
+    # Every vertex's z = 1 + 30 = 31.
+    np.testing.assert_allclose(verts[:, 2], 31.0, atol=1e-5)

--- a/openspec/changes/worldscan-v2.3-depth-fusion/proposal.md
+++ b/openspec/changes/worldscan-v2.3-depth-fusion/proposal.md
@@ -1,0 +1,106 @@
+# worldscan-v2.3-depth-fusion — Proposal
+
+## What
+
+Implement the `DepthFusionBackend` slot — one of the four reconstruction
+backends that the worldscan-v2 architecture left as a stub in PR-A
+(`backend/src/features/reconstruction/backends/depth_fusion.py`).
+
+The implementation is a server-side port of matthew's browser-side pipeline
+in `prototype/v4.html` (currently runnable via `python -m rl_env serve`):
+
+1. Per frame: metric depth from Depth-Anything-V2-Metric-Indoor-Small
+   (already wired through `rl_env.server._ensure_depth_model`).
+2. Per frame: SuperPoint feature extraction (ONNX, fabio-sim/LightGlue-ONNX).
+3. Per pair: LightGlue matching (ONNX) against the best previous frame.
+4. Per pair: median-robust linear depth calibration `z_ref ≈ k·z_new + c`
+   to correct monocular drift before pose alignment.
+5. Per pair: rigid Umeyama + RANSAC (200 iters, 0.15 m threshold, ≥10
+   inliers, scale fixed at 1 since depth is metric).
+6. Per frame: back-projected colored triangle mesh in world frame, with
+   depth-discontinuity culling (>0.30 m span per quad) to avoid stretched
+   ghost geometry around object edges.
+
+Outputs `mesh.ply` + `points.ply` under `out_dir`. Reuses matthew's depth
+model loaders directly via the `rl_env` workspace member, so the legacy
+Flask `/api/depth` endpoint and the new backend share identical weights.
+
+## Why now
+
+- **The architecture explicitly reserved this slot.** PR-A registered
+  `depth_fusion` with `implemented = False` and a `NotImplementedError`
+  pointing at this change. The registry pattern was set up to make this a
+  drop-in.
+- **Matthew's PR #22 demonstrated the algorithm works.** The browser
+  pipeline already reconstructs from multi-photo input on consumer
+  hardware. Porting it server-side puts depth-fusion on equal footing with
+  the `vggt`, `colmap`, and `splat` backends inside the FastAPI flow
+  (selectable from the frontend, persisted in the DB, validated by the
+  validation gate).
+- **No GPU-feature-matching alternative exists in the new flow.** `vggt`
+  needs a serious GPU; `colmap` is classical SfM (slow); `splat` is
+  gaussian splatting (different output shape). Depth-fusion is the only
+  backend that produces a triangle mesh from sparse keypoint-matched depth
+  on commodity hardware (CPU works, GPU optional for speed).
+
+## What it changes
+
+- **MODIFIED** capability `video-reconstruction`: `depth_fusion` flips
+  `implemented = False → True`. No interface change — the existing
+  `ReconstructionBackend` ABC and `ReconstructionInput/Output` carry it.
+- **NEW internal modules** (private to `backends/`):
+  - `_geometry.py` — pure-NumPy math (`robust_linear_fit`, `umeyama_rigid`,
+    `ransac_umeyama`, `back_project`, `assume_intrinsics`).
+  - `_models.py` — lazy-loaded depth pipelines + ONNX SuperPoint/LightGlue
+    sessions, wrapping `rl_env.server` helpers.
+- **Backend deps**: `transformers`, `torchvision`, `onnxruntime` added to
+  `backend/pyproject.toml` (already present in `rl_env`).
+- **Unit tests**: `backend/tests/test_depth_fusion_geometry.py` covers the
+  math (depth calibration, Umeyama, RANSAC inlier consensus, back-projection
+  with discontinuities).
+
+## Non-goals
+
+- **TSDF / volumetric fusion.** Matthew's pipeline doesn't do TSDF — it
+  produces per-frame back-projected meshes in shared world space. We
+  preserve that simplicity. A future change can add open3d-based TSDF if
+  mesh quality demands it.
+- **Bundle adjustment.** Per-pair pose only. Global optimization is left
+  for a follow-up.
+- **Depth-Pro (`apple/DepthPro-hf`)** is supported via the same code path
+  but not the default — `indoor` (Depth-Anything-V2-Metric-Indoor-Small) is
+  smaller, faster, and matches v4.html's default.
+- **Backend selection UI changes.** The frontend already lists implemented
+  backends; nothing to change there.
+
+## Acceptance
+
+1. `pytest backend/tests/test_depth_fusion_geometry.py` passes locally
+   (math correctness — runs without GPU or model weights).
+2. `GET /api/reconstruction/backends` returns `depth_fusion` with
+   `implemented: true, requires_gpu: true`.
+3. End-to-end on a short clip (5–10 frames, walking around a room):
+   - `POST /api/projects/{id}/reconstruct` with body `{"backend": "depth_fusion"}`
+     triggers an Inngest run.
+   - On completion: `mesh.ply` and `points.ply` exist under
+     `data/projects/{id}/reconstruction/`.
+   - `Reconstruction.backend_meta` includes `n_fused`, `n_failed_fusion`,
+     `avg_inliers`, vertex/face counts.
+4. The legacy Flask flow still works (`python -m rl_env serve` →
+   `open prototype/v4.html`) — confirming we didn't break matthew's
+   reference implementation.
+
+## Open questions
+
+- **Intrinsics.** No real camera intrinsics yet; we default to 60° hFOV
+  (matches v4.html). Frontend could let users pick "phone" / "DSLR"
+  presets or read EXIF. Out of scope for this change.
+- **Depth-Pro FOV.** Depth-Pro emits a per-image FOV estimate; we surface
+  it in `backend_meta["fov_deg"]` but don't yet use it to override the
+  default intrinsics. Worth wiring up in a follow-up — should improve
+  reconstruction quality on wide-angle phone footage.
+- **GPU detection.** `requires_gpu = True` advertises the requirement but
+  the implementation runs (slowly) on CPU. Should the runtime check
+  `torch.cuda.is_available() or torch.backends.mps.is_available()` and
+  refuse on CPU, like `vggt`? Probably yes — but matthew's flow worked on
+  CPU, so I left it permissive.


### PR DESCRIPTION
## Summary

Implements `DepthFusionBackend.reconstruct()` — the stub PR-A explicitly reserved for matthew's depth-fusion method. Ports the algorithm from `prototype/v4.html` (currently runnable via `python -m rl_env serve`) into the new FastAPI reconstruction flow, so depth-fusion sits alongside `vggt`, `colmap`, and `splat` as a selectable backend.

- Per frame: Depth-Anything-V2-Metric-Indoor (default) or Apple Depth-Pro for metric depth + SuperPoint ONNX features
- Per pair: LightGlue ONNX matching against the best previous frame; Theil–Sen robust depth calibration; RANSAC + rigid Umeyama (scale fixed at 1, since depth is metric)
- Per frame: back-projected colored triangle mesh with depth-discontinuity culling
- Output: `mesh.ply` + `points.ply` + `camera_poses` + `backend_meta` (n_fused, avg_inliers, etc.)

Depth weights are loaded via `rl_env.server._ensure_depth_model`, so matthew's legacy `/api/depth` Flask endpoint and this backend share the same in-memory pipeline (one source of truth). `rl_env.server` imports are deferred to call sites so flask isn't required for backend test collection.

## Files

- `backend/src/features/reconstruction/backends/depth_fusion.py` — full implementation, `implemented = True`
- `backend/src/features/reconstruction/backends/_geometry.py` (new) — pure-numpy math: Theil–Sen fit, Umeyama, RANSAC, back-projection, intrinsics defaults
- `backend/src/features/reconstruction/backends/_models.py` (new) — lazy depth pipelines + ONNX SuperPoint/LightGlue sessions
- `backend/tests/test_depth_fusion_geometry.py` (new) — 10 unit tests for the math (all passing)
- `backend/pyproject.toml` — adds `transformers`, `torchvision`, `onnxruntime`
- `openspec/changes/worldscan-v2.3-depth-fusion/proposal.md` (new) — change doc matching the project's openspec pattern

## Test plan

- [x] `pytest backend/tests/test_depth_fusion_geometry.py --noconftest` — 10 passed locally (math correctness, no GPU needed)
- [ ] `GET /api/reconstruction/backends` returns `depth_fusion` with `implemented: true`
- [ ] End-to-end: upload a short clip, pick `depth_fusion` from the frontend, observe Inngest job → produces non-empty `mesh.ply` + `points.ply` under `data/projects/{id}/reconstruction/`
- [ ] Open the resulting PLY in any viewer (or three.js drag-and-drop) and verify it looks like a coherent room
- [ ] `python -m rl_env serve` → `open prototype/v4.html` still works in parallel (confirms we didn't break matthew's legacy flow)

## What I couldn't validate

End-to-end requires Depth-Anything model weights (~100 MB) + GPU/MPS + Inngest stack running locally. I ran the math tests but the "does it produce a good mesh on real frames" validation needs a human in the loop. Algorithm matches matthew's JS pipeline step-for-step, but ONNX preprocessing (resize, normalization, channel order, keypoint normalization) is fertile ground for off-by-one bugs vs. the browser implementation — worth eyeballing the SuperPoint/LightGlue I/O in `_models.py` against matthew's `prototype/v4.html` JS calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)