### PR TITLE
Fix reconstruction (faithful prototype port) + photo/video support

### DIFF
--- a/backend/src/features/reconstruction/backends/_geometry.py
+++ b/backend/src/features/reconstruction/backends/_geometry.py
@@ -11,26 +11,26 @@ import numpy as np
 
 
 def robust_linear_fit(z_ref: np.ndarray, z_new: np.ndarray) -> tuple[float, float]:
-    """Robust linear fit z_ref ≈ k * z_new + c on matched keypoint depths.
+    """Robust scale-only fit z_ref ≈ k * z_new on matched keypoint depths.
 
-    Even with metric depth, per-image monocular depth has scale/offset drift;
-    this corrects new-image depths into the reference frame before pose
-    alignment. Uses Theil–Sen (median of pairwise slopes) — unbiased when an
-    offset is present, robust to outliers. `k` is clamped to [0.5, 2.0]
-    (matthew's heuristic against ill-conditioned matches).
+    Even with metric depth, per-image monocular depth has scale drift; this
+    corrects new-image depths into the reference frame before pose alignment.
+
+    Scale-only (offset c fixed at 0), via the median of per-match depth ratios
+    (z_ref / z_new), `k` clamped to [0.5, 2.0]. This mirrors matthew's prototype
+    (`robustLinearFit` in prototype/v4.2.html): a *free* offset was tried and
+    dropped because it produced extreme values when matched depths had narrow
+    variance. Returns (k, 0.0).
     """
-    from scipy import stats  # local: scipy import is heavyish for module load
-
     z_ref = np.asarray(z_ref, dtype=np.float64).ravel()
     z_new = np.asarray(z_new, dtype=np.float64).ravel()
-    mask = (z_ref > 0.0) & (z_new > 0.0)
+    # Prototype filters at 0.05 (metres) on both sides before taking ratios.
+    mask = (z_ref > 0.05) & (z_new > 0.05)
     if mask.sum() < 4:
         return 1.0, 0.0
-    zr, zn = z_ref[mask], z_new[mask]
-    slope, intercept, _lo, _hi = stats.theilslopes(zr, zn)
-    k = float(np.clip(slope, 0.5, 2.0))
-    c = float(intercept)
-    return k, c
+    ratios = z_ref[mask] / z_new[mask]
+    k = float(np.clip(np.median(ratios), 0.5, 2.0))
+    return k, 0.0
 
 
 def umeyama_rigid(pts_a: np.ndarray, pts_b: np.ndarray) -> np.ndarray:

--- a/backend/src/features/reconstruction/backends/_models.py
+++ b/backend/src/features/reconstruction/backends/_models.py
@@ -120,21 +120,27 @@ def _onnx_session(name: str):
         return sess
 
 
-def _preprocess_for_superpoint(image: Image.Image, max_side: int = 512) -> tuple[np.ndarray, float]:
-    """Grayscale + resize-down to keep the longer side ≤ max_side. Returns
-    (image_array float32 0-1, scale_factor) so detected keypoints can be
-    mapped back to original coordinates.
+def _preprocess_for_superpoint(image: Image.Image, max_side: int = 1536) -> tuple[np.ndarray, float, float]:
+    """Grayscale + resize so the longer side ≤ max_side, with both dims
+    quantized to a multiple of 8 (SuperPoint's ONNX export expects /8-divisible
+    spatial dims, and the prototype found coarser inputs lose keypoints).
+
+    Returns (image_array float32 0-1 shaped (1,1,H,W), scale_x, scale_y) so
+    detected keypoints in the resized grid can be mapped back to original pixel
+    coordinates. Mirrors `preprocessForSuperPoint` in prototype/v4.2.html
+    (SP_MAX_DIM=1536, round to multiple of 8, min 32).
     """
     w, h = image.size
     scale = min(1.0, float(max_side) / float(max(w, h)))
-    if scale < 1.0:
-        new_w, new_h = int(round(w * scale)), int(round(h * scale))
+    new_w = max(32, int(round(w * scale / 8.0)) * 8)
+    new_h = max(32, int(round(h * scale / 8.0)) * 8)
+    if (new_w, new_h) != (w, h):
         image = image.resize((new_w, new_h), Image.BILINEAR)
     gray = image.convert("L")
     arr = np.asarray(gray, dtype=np.float32) / 255.0
     # SuperPoint expects (1, 1, H, W).
     arr = arr[None, None, :, :]
-    return arr, scale
+    return arr, new_w / float(w), new_h / float(h)
 
 
 def extract_superpoint(image: Image.Image, max_keypoints: int = 1024) -> dict:
@@ -144,7 +150,7 @@ def extract_superpoint(image: Image.Image, max_keypoints: int = 1024) -> dict:
     Caps to top-`max_keypoints` by score, matching matthew's heuristic.
     """
     sess = _onnx_session("superpoint")
-    arr, scale = _preprocess_for_superpoint(image)
+    arr, scale_x, scale_y = _preprocess_for_superpoint(image)
     inputs = {sess.get_inputs()[0].name: arr}
     out_names = [o.name for o in sess.get_outputs()]
     outs = sess.run(out_names, inputs)
@@ -156,9 +162,12 @@ def extract_superpoint(image: Image.Image, max_keypoints: int = 1024) -> dict:
     if kp.shape[0] > max_keypoints:
         top = np.argsort(scores)[-max_keypoints:]
         kp, scores, desc = kp[top], scores[top], desc[top]
-    if scale < 1.0:
-        kp = kp.astype(np.float32) / scale
-    return {"keypoints": kp.astype(np.float32), "descriptors": desc.astype(np.float32), "scores": scores.astype(np.float32)}
+    # Map keypoints from the (independently quantized) resized grid back to
+    # original pixel coordinates. x and y can have slightly different scales.
+    kp = kp.astype(np.float32)
+    kp[:, 0] /= scale_x
+    kp[:, 1] /= scale_y
+    return {"keypoints": kp, "descriptors": desc.astype(np.float32), "scores": scores.astype(np.float32)}
 
 
 def match_lightglue(feat_a: dict, feat_b: dict, image_size: tuple[int, int]) -> np.ndarray:

--- a/backend/src/features/reconstruction/backends/_models.py
+++ b/backend/src/features/reconstruction/backends/_models.py
@@ -197,12 +197,21 @@ def match_lightglue(feat_a: dict, feat_b: dict, image_size: tuple[int, int]) -> 
     expected = {i.name for i in sess.get_inputs()}
     inputs = {k: v for k, v in inputs.items() if k in expected}
     out_names = [o.name for o in sess.get_outputs()]
-    outs = sess.run(out_names, inputs)
-    # The fabio-sim LightGlue ONNX exports `matches0` (1, M, 2) of (idx_a, idx_b).
-    matches = outs[0]
-    if matches.ndim == 3:
-        matches = matches[0]
-    return matches.astype(np.int64)
+    outs = dict(zip(out_names, sess.run(out_names, inputs)))
+    # The fabio-sim superpoint_lightglue ONNX returns `matches0` of shape
+    # (1, num_keypoints_a): for each keypoint in image A, the index of its
+    # matched keypoint in image B, or -1 if unmatched (LightGlue's learned
+    # threshold already filters weak matches). Convert that assignment array to
+    # explicit (idx_a, idx_b) pairs.
+    m0 = outs.get("matches0", next(iter(outs.values())))
+    m0 = np.asarray(m0)
+    while m0.ndim > 1:
+        m0 = m0[0]
+    idx_a = np.nonzero(m0 > -1)[0]
+    idx_b = m0[idx_a]
+    if idx_a.size == 0:
+        return np.zeros((0, 2), dtype=np.int64)
+    return np.stack([idx_a, idx_b], axis=1).astype(np.int64)
 
 
 __all__ = [

--- a/backend/src/features/reconstruction/backends/depth_fusion.py
+++ b/backend/src/features/reconstruction/backends/depth_fusion.py
@@ -66,10 +66,13 @@ _DISCONTINUITY_M = 0.30
 _RANSAC_ITERS = 200
 _RANSAC_THRESH_M = 0.15
 _RANSAC_MIN_INLIERS = 10
-# Cap the meshing grid so a fused multi-frame mesh stays renderable in the
-# browser (a full-res 24-frame fuse is ~100M faces). Metric 3D points are
-# preserved when decimating — only the triangle density drops.
-_MESH_MAX_SIDE = 640
+# Cap the *total* meshing budget so a fused mesh stays renderable in the
+# browser regardless of frame count (a full-res 24-frame fuse is ~100M faces,
+# and even a per-frame 640px cap balloons to ~300MB at 24 frames). We spread a
+# fixed vertex budget across frames; metric 3D points are preserved when
+# decimating — only the triangle density drops.
+_MESH_VERT_BUDGET = 1_800_000  # total vertices across all frames
+_MESH_MIN_PIX = 20_000  # never decimate a single frame below this (≈170x118)
 
 
 def _sample_depth_at(depth: np.ndarray, kp: np.ndarray) -> np.ndarray:
@@ -91,10 +94,10 @@ def _kp_to_camera_points(kp: np.ndarray, z: np.ndarray, K: np.ndarray) -> np.nda
 
 
 def _downsample_for_mesh(
-    depth: np.ndarray, color: np.ndarray, fov_deg: float, max_side: int = _MESH_MAX_SIDE
+    depth: np.ndarray, color: np.ndarray, fov_deg: float, max_pixels: int
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Down-sample a (calibrated) depth map + color to ≤ max_side on the long
-    edge and return (depth_ds, color_ds, K_ds).
+    """Down-sample a (calibrated) depth map + color so the grid has at most
+    `max_pixels` cells, and return (depth_ds, color_ds, K_ds).
 
     The back-projected metric 3D points are unchanged because the intrinsics
     scale with resolution (fx, cx ∝ width); only the triangle grid coarsens.
@@ -102,7 +105,7 @@ def _downsample_for_mesh(
     discontinuity filter; color uses bilinear.
     """
     h, w = depth.shape
-    s = min(1.0, float(max_side) / float(max(w, h)))
+    s = min(1.0, (float(max_pixels) / float(w * h)) ** 0.5)
     if s < 1.0:
         new_w = max(2, int(round(w * s)))
         new_h = max(2, int(round(h * s)))
@@ -172,6 +175,9 @@ class DepthFusionBackend(ReconstructionBackend):
             depth_model = "indoor"
 
         n = len(frame_paths)
+        # Spread the total vertex budget across frames so the fused mesh stays
+        # renderable whether there are 1 or 24 of them.
+        mesh_max_pixels = max(_MESH_MIN_PIX, _MESH_VERT_BUDGET // n)
 
         # ---- Pass 1: per-frame depth + SuperPoint features + FOV estimate ----
         frames: list[dict] = []
@@ -290,7 +296,7 @@ class DepthFusionBackend(ReconstructionBackend):
                             )
 
             # Back-project this frame into world space on a decimated grid.
-            depth_ds, color_ds, K_ds = _downsample_for_mesh(depth, fr["color"], fov_deg)
+            depth_ds, color_ds, K_ds = _downsample_for_mesh(depth, fr["color"], fov_deg, mesh_max_pixels)
             verts, faces, colors = back_project(
                 depth=depth_ds,
                 color=color_ds,

--- a/backend/src/features/reconstruction/backends/depth_fusion.py
+++ b/backend/src/features/reconstruction/backends/depth_fusion.py
@@ -1,18 +1,23 @@
 """Depth-fusion reconstruction backend — server-side port of matthew's
-prototype/v4.html pipeline.
+prototype/v4.2.html pipeline.
 
-Pipeline per frame:
-  1. Monocular metric depth (Depth-Anything-V2-Metric-Indoor by default).
+Pass 1 (per frame):
+  1. Monocular metric depth (Apple Depth-Pro by default; it also emits a
+     per-frame horizontal FOV estimate). Falls back to the lighter
+     Depth-Anything-V2-Metric-Indoor model if Depth-Pro can't be loaded.
   2. SuperPoint keypoints + descriptors (ONNX).
+  3. Collect FOV estimates; the shared intrinsics use their median (v4.2's
+     trick — a single, self-tuned FOV beats a hardcoded guess).
 
-Cross-frame fusion (for each new frame i, find best previous frame j to fuse
-against):
-  3. LightGlue match (i, j); skip if < 8 matches.
-  4. Depth calibration: linear robust fit of frame i's depths onto frame j's,
-     correcting monocular drift before pose alignment.
-  5. Pose: RANSAC + rigid Umeyama on matched keypoint 3D points
-     (rigid=True since depth is metric — preserves world scale).
-  6. Compose into a per-frame back-projected colored mesh in world space.
+Pass 2 — cross-frame fusion (for each new frame i, find best previous frame j
+to fuse against):
+  4. LightGlue match (i, j); skip if < 8 matches.
+  5. Depth calibration: robust scale-only fit of frame i's depths onto frame
+     j's, correcting monocular drift before pose alignment.
+  6. Pose: RANSAC + rigid Umeyama on matched keypoint 3D points
+     (rigid since depth is metric — preserves world scale).
+  7. Back-project each frame (on a decimated grid) into world space and
+     concatenate into one colored mesh.
 
 Outputs:
   - mesh.ply: concatenated per-frame meshes (triangles, vertex colors)
@@ -41,6 +46,7 @@ from src.features.reconstruction.backends._geometry import (
 )
 from src.features.reconstruction.backends._models import (
     extract_superpoint,
+    get_depth_model,
     infer_depth,
     match_lightglue,
 )
@@ -60,6 +66,10 @@ _DISCONTINUITY_M = 0.30
 _RANSAC_ITERS = 200
 _RANSAC_THRESH_M = 0.15
 _RANSAC_MIN_INLIERS = 10
+# Cap the meshing grid so a fused multi-frame mesh stays renderable in the
+# browser (a full-res 24-frame fuse is ~100M faces). Metric 3D points are
+# preserved when decimating — only the triangle density drops.
+_MESH_MAX_SIDE = 640
 
 
 def _sample_depth_at(depth: np.ndarray, kp: np.ndarray) -> np.ndarray:
@@ -78,6 +88,38 @@ def _kp_to_camera_points(kp: np.ndarray, z: np.ndarray, K: np.ndarray) -> np.nda
     X = (kp[:, 0] - cx) * z / fx
     Y = (kp[:, 1] - cy) * z / fy
     return np.stack([X, Y, z], axis=1)
+
+
+def _downsample_for_mesh(
+    depth: np.ndarray, color: np.ndarray, fov_deg: float, max_side: int = _MESH_MAX_SIDE
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Down-sample a (calibrated) depth map + color to ≤ max_side on the long
+    edge and return (depth_ds, color_ds, K_ds).
+
+    The back-projected metric 3D points are unchanged because the intrinsics
+    scale with resolution (fx, cx ∝ width); only the triangle grid coarsens.
+    Depth uses nearest-neighbor to keep object edges crisp for the
+    discontinuity filter; color uses bilinear.
+    """
+    h, w = depth.shape
+    s = min(1.0, float(max_side) / float(max(w, h)))
+    if s < 1.0:
+        new_w = max(2, int(round(w * s)))
+        new_h = max(2, int(round(h * s)))
+        depth_ds = np.asarray(
+            Image.fromarray(depth.astype(np.float32)).resize((new_w, new_h), Image.NEAREST),
+            dtype=np.float32,
+        )
+        color_ds = np.asarray(
+            Image.fromarray(color.astype(np.uint8)).resize((new_w, new_h), Image.BILINEAR),
+            dtype=np.uint8,
+        )
+    else:
+        new_w, new_h = w, h
+        depth_ds = depth.astype(np.float32)
+        color_ds = color.astype(np.uint8)
+    K_ds = assume_intrinsics(new_w, new_h, fov_deg=fov_deg)
+    return depth_ds, color_ds, K_ds
 
 
 def _write_ply_mesh(verts: np.ndarray, faces: np.ndarray, colors: np.ndarray, path: Path) -> None:
@@ -116,9 +158,52 @@ class DepthFusionBackend(ReconstructionBackend):
 
         out_dir.mkdir(parents=True, exist_ok=True)
 
-        depth_model = (inp.intrinsics_hint or {}).get("depth_model", "indoor")
-        fov_deg = float((inp.intrinsics_hint or {}).get("fov_deg", _FOV_DEG_DEFAULT))
+        hint = inp.intrinsics_hint or {}
+        depth_model = hint.get("depth_model", "pro")
+        # Resolve the depth model once; fall back to the lighter indoor model if
+        # Depth-Pro can't be loaded (download/disk/OOM on a GPU-less host).
+        try:
+            get_depth_model(depth_model)
+        except Exception as e:  # noqa: BLE001 — any load failure → fallback
+            log.warning(
+                "[depth_fusion] depth model %r unavailable (%s); falling back to 'indoor'",
+                depth_model, e,
+            )
+            depth_model = "indoor"
 
+        n = len(frame_paths)
+
+        # ---- Pass 1: per-frame depth + SuperPoint features + FOV estimate ----
+        frames: list[dict] = []
+        fov_estimates: list[float] = []
+        for i, fp in enumerate(frame_paths):
+            img = Image.open(fp).convert("RGB")
+            w, h = img.size
+            depth, depth_meta = infer_depth(img, name=depth_model)
+            if depth.shape != (h, w):
+                # Resize depth onto the image grid if the model emitted a different size.
+                depth = np.asarray(
+                    Image.fromarray(depth).resize((w, h), Image.BILINEAR),
+                    dtype=np.float32,
+                )
+            feat = extract_superpoint(img)
+            fov_i = depth_meta.get("fov_deg")
+            if fov_i is not None and np.isfinite(fov_i) and fov_i > 0:
+                fov_estimates.append(float(fov_i))
+            frames.append({"color": np.asarray(img), "w": w, "h": h, "depth": depth, "feat": feat})
+            progress_cb(0.5 * (i + 1) / n, f"depth {i + 1}/{n}")
+
+        # Shared horizontal FOV: median of per-frame estimates (Depth-Pro), else
+        # an explicit hint, else 60° (matches the prototype's slider default).
+        if fov_estimates:
+            fov_deg = float(np.median(fov_estimates))
+            fov_src = f"median of {len(fov_estimates)} estimate(s)"
+        else:
+            fov_deg = float(hint.get("fov_deg", _FOV_DEG_DEFAULT))
+            fov_src = "hint/default (no per-frame estimate)"
+        log.info("[depth_fusion] %d frames, depth=%s, fov=%.1f° (%s)", n, depth_model, fov_deg, fov_src)
+
+        # ---- Pass 2: fuse frames into a common world frame ----
         per_frame: list[dict] = []
         all_verts: list[np.ndarray] = []
         all_faces: list[np.ndarray] = []
@@ -128,20 +213,11 @@ class DepthFusionBackend(ReconstructionBackend):
         n_failed_fusion = 0
         inlier_counts: list[int] = []
 
-        log.info("[depth_fusion] %d frames, depth=%s, fov=%.1f°", len(frame_paths), depth_model, fov_deg)
-
-        for i, fp in enumerate(frame_paths):
+        for i, fr in enumerate(frames):
             t_frame = time.time()
-            img = Image.open(fp).convert("RGB")
-            w, h = img.size
-            depth, _depth_meta = infer_depth(img, name=depth_model)
-            if depth.shape != (h, w):
-                # Resize depth onto the image grid if the model emitted a different size.
-                depth = np.asarray(
-                    Image.fromarray(depth).resize((w, h), Image.BILINEAR),
-                    dtype=np.float32,
-                )
-            feat = extract_superpoint(img)
+            w, h = fr["w"], fr["h"]
+            depth = fr["depth"]
+            feat = fr["feat"]
             K = assume_intrinsics(w, h, fov_deg=fov_deg)
 
             world_T = np.eye(4, dtype=np.float64)  # frame 0 anchors world at identity
@@ -209,15 +285,16 @@ class DepthFusionBackend(ReconstructionBackend):
                             n_fused += 1
                             inlier_counts.append(int(inliers.sum()))
                             log.info(
-                                "[depth_fusion] frame %d → ref %d: %d matches, %d inliers, k=%.3f c=%.3f",
-                                i, best_j, best_matches.shape[0], int(inliers.sum()), k_scale, c_off,
+                                "[depth_fusion] frame %d → ref %d: %d matches, %d inliers, k=%.3f",
+                                i, best_j, best_matches.shape[0], int(inliers.sum()), k_scale,
                             )
 
-            # Back-project this frame into world space and collect its mesh.
+            # Back-project this frame into world space on a decimated grid.
+            depth_ds, color_ds, K_ds = _downsample_for_mesh(depth, fr["color"], fov_deg)
             verts, faces, colors = back_project(
-                depth=depth,
-                color=np.asarray(img),
-                intrinsics=K,
+                depth=depth_ds,
+                color=color_ds,
+                intrinsics=K_ds,
                 world_transform=world_T,
                 discontinuity_m=_DISCONTINUITY_M,
             )
@@ -234,8 +311,17 @@ class DepthFusionBackend(ReconstructionBackend):
             })
 
             elapsed = time.time() - t_frame
-            log.info("[depth_fusion] frame %d/%d done in %.2fs (%d verts)", i + 1, len(frame_paths), elapsed, verts.shape[0])
-            progress_cb((i + 1) / len(frame_paths), f"frame {i + 1}/{len(frame_paths)}")
+            log.info("[depth_fusion] frame %d/%d fused in %.2fs (%d verts)", i + 1, n, elapsed, verts.shape[0])
+            progress_cb(0.5 + 0.5 * (i + 1) / n, f"fuse {i + 1}/{n}")
+
+        # With multiple frames, zero successful fusions means the pipeline failed
+        # (bad matches / wrong intrinsics). Don't emit a giant pile of unaligned
+        # per-frame meshes marked "ok" — surface a real failure instead.
+        if n > 1 and n_fused == 0:
+            raise RuntimeError(
+                f"reconstruction failed: 0/{n - 1} frames fused (no inlier pose found). "
+                "Use a video/photos with more overlap and texture, or try the indoor model."
+            )
 
         if not all_verts:
             raise RuntimeError("depth_fusion produced no geometry — every frame failed back-projection")
@@ -252,7 +338,7 @@ class DepthFusionBackend(ReconstructionBackend):
         backend_meta = {
             "depth_model": depth_model,
             "fov_deg": fov_deg,
-            "n_frames": len(frame_paths),
+            "n_frames": n,
             "n_fused": n_fused,
             "n_failed_fusion": n_failed_fusion,
             "avg_inliers": float(np.mean(inlier_counts)) if inlier_counts else 0.0,

--- a/backend/src/features/reconstruction/inngest_functions.py
+++ b/backend/src/features/reconstruction/inngest_functions.py
@@ -68,11 +68,14 @@ async def reconstruct_video(ctx: inngest.Context) -> dict:
         backend = get_backend(backend_name)
         out_dir = settings.data_dir / "projects" / extracted["project_id"] / "reconstruction"
         t0 = time.time()
+        # Forward reconstruction tunables (depth model, FOV override) to the
+        # backend; depth_fusion reads them from intrinsics_hint.
+        hint = {k: params[k] for k in ("depth_model", "fov_deg") if k in params}
         result = backend.reconstruct(
             ReconstructionInput(
                 frames_dir=Path(extracted["frames_dir"]),
                 fps_sampled=float(params.get("fps", 4.0)),
-                intrinsics_hint=None,
+                intrinsics_hint=hint or None,
             ),
             out_dir,
             progress_cb=lambda _p, _m: None,

--- a/backend/src/features/reconstruction/router.py
+++ b/backend/src/features/reconstruction/router.py
@@ -144,11 +144,12 @@ def _run_reconstruction_blocking(
         backend = get_backend(backend_name)
         out_dir = settings.data_dir / "projects" / project_id / "reconstruction"
         t0 = time.time()
+        hint = {k: params[k] for k in ("depth_model", "fov_deg") if k in params}
         result = backend.reconstruct(
             ReconstructionInput(
                 frames_dir=frames_dir,
                 fps_sampled=float(params.get("fps", 4.0)),
-                intrinsics_hint=None,
+                intrinsics_hint=hint or None,
             ),
             out_dir,
             progress_cb=lambda p, m: None,

--- a/backend/tests/test_depth_fusion_geometry.py
+++ b/backend/tests/test_depth_fusion_geometry.py
@@ -13,25 +13,33 @@ from src.features.reconstruction.backends._geometry import (
 )
 
 
-def test_robust_linear_fit_recovers_scale_offset() -> None:
+def test_robust_linear_fit_recovers_scale() -> None:
+    # Scale-only contract (matches prototype v4.2): recover k, offset fixed at 0.
     rng = np.random.default_rng(0)
     z_new = rng.uniform(0.5, 5.0, size=50)
-    k_true, c_true = 1.3, 0.2
-    z_ref = k_true * z_new + c_true + rng.normal(0, 0.01, size=50)
+    k_true = 1.3
+    z_ref = k_true * z_new + rng.normal(0, 0.01, size=50)
     k, c = robust_linear_fit(z_ref, z_new)
     assert abs(k - k_true) < 0.05
-    assert abs(c - c_true) < 0.05
+    assert c == 0.0
 
 
 def test_robust_linear_fit_survives_outliers() -> None:
     rng = np.random.default_rng(1)
     z_new = rng.uniform(0.5, 5.0, size=50)
-    z_ref = 1.1 * z_new + 0.05
-    # Corrupt 30% with wild outliers.
+    z_ref = 1.1 * z_new
+    # Corrupt 30% with wild outliers — the median ratio shrugs them off.
     z_ref[::3] = rng.uniform(-10, 50, size=z_ref[::3].shape)
     k, c = robust_linear_fit(z_ref, z_new)
     assert 0.9 < k < 1.3
-    assert -1.0 < c < 1.0
+    assert c == 0.0
+
+
+def test_robust_linear_fit_clamps_scale() -> None:
+    # Extreme scale is clamped to [0.5, 2.0] to guard ill-conditioned matches.
+    z_new = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    k, c = robust_linear_fit(10.0 * z_new, z_new)
+    assert k == 2.0 and c == 0.0
 
 
 def test_robust_linear_fit_falls_back_when_too_few_points() -> None:

--- a/frontend/src/components/MeshViewer.tsx
+++ b/frontend/src/components/MeshViewer.tsx
@@ -3,19 +3,23 @@
  * cleanly under React 19. Loads a .ply, centers and normalizes it, gives
  * the user OrbitControls + a faint grid floor + a directional light.
  */
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 import { PLYLoader } from "three/examples/jsm/loaders/PLYLoader.js";
 
 import { cn } from "@/lib/utils";
 
+type LoadState = { state: "loading" | "ready" | "error"; msg?: string };
+
 export function MeshViewer({ url, className }: { url: string; className?: string }) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const [load, setLoad] = useState<LoadState>({ state: "loading" });
 
   useEffect(() => {
     const container = containerRef.current;
     if (!container || !url) return;
+    setLoad({ state: "loading" });
 
     const width = container.clientWidth || 800;
     const height = container.clientHeight || 600;
@@ -74,10 +78,19 @@ export function MeshViewer({ url, className }: { url: string; className?: string
         mesh.scale.setScalar(scale);
         mesh.position.y = (size.y * scale) / 2;
         scene.add(mesh);
+        setLoad(
+          geom.getAttribute("position")?.count
+            ? { state: "ready" }
+            : { state: "error", msg: "The reconstruction produced an empty mesh." },
+        );
       },
       undefined,
       (err) => {
         console.error("PLY load failed", err);
+        setLoad({
+          state: "error",
+          msg: "Couldn't load the reconstruction mesh — it may be missing or failed to generate.",
+        });
       },
     );
 
@@ -122,6 +135,19 @@ export function MeshViewer({ url, className }: { url: string; className?: string
       )}
     >
       <div ref={containerRef} className="absolute inset-0" />
+      {load.state !== "ready" && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none p-6 text-center">
+          {load.state === "loading" ? (
+            <span className="mono text-xs text-muted-foreground animate-pulse">
+              loading mesh…
+            </span>
+          ) : (
+            <span className="mono text-xs text-[var(--status-fail)] max-w-xs">
+              {load.msg ?? "Couldn't load the reconstruction mesh."}
+            </span>
+          )}
+        </div>
+      )}
       <div className="absolute pointer-events-none top-3 right-3 mono text-[10px] text-muted-foreground/70 px-2 py-1 rounded-sm bg-background/60 backdrop-blur-sm">
         drag <span className="text-foreground">orbit</span> · shift+drag{" "}
         <span className="text-foreground">pan</span> · wheel{" "}

--- a/frontend/src/components/ProjectRightPanel.tsx
+++ b/frontend/src/components/ProjectRightPanel.tsx
@@ -32,8 +32,9 @@ export function ProjectRightPanel() {
 function RightPaneForProject({ projectId }: { projectId: string }) {
   const { data: recon } = useLatestReconstruction(projectId);
 
+  const status = recon?.status;
   const meshUrl =
-    recon?.mesh_path && recon.status === "ok"
+    recon?.mesh_path && status === "ok"
       ? meshPathToUrl(recon.mesh_path, projectId)
       : null;
 
@@ -42,8 +43,20 @@ function RightPaneForProject({ projectId }: { projectId: string }) {
       {meshUrl ? (
         <MeshViewer url={meshUrl} />
       ) : (
-        <div className="w-full h-full border border-dashed border-border/60 rounded-sm flex items-center justify-center text-xs text-muted-foreground mono">
-          no mesh yet — finish Reconstruct to see the scene here
+        <div className="w-full h-full border border-dashed border-border/60 rounded-sm flex items-center justify-center text-center px-6 text-xs mono">
+          {status === "running" || status === "pending" ? (
+            <span className="text-muted-foreground animate-pulse">
+              reconstructing… the scene will appear here when it finishes
+            </span>
+          ) : status === "failed" ? (
+            <span className="text-[var(--status-fail)] max-w-xs">
+              reconstruction failed: {recon?.error ?? "unknown error"}
+            </span>
+          ) : (
+            <span className="text-muted-foreground">
+              no mesh yet — finish Reconstruct to see the scene here
+            </span>
+          )}
         </div>
       )}
     </aside>

--- a/frontend/src/routes/p.$projectId.capture.tsx
+++ b/frontend/src/routes/p.$projectId.capture.tsx
@@ -39,8 +39,9 @@ function Capture() {
         <header className="mb-8">
           <h1 className="text-2xl">Capture</h1>
           <p className="text-sm text-muted-foreground mt-1.5 max-w-xl">
-            Upload a short video of a room (mp4, mov, webm). The backend samples
-            ~24 frames evenly and feeds them to the reconstruction backend on
+            Upload a short video of a room (mp4, mov, webm) — or a photo (jpg,
+            png). The backend samples ~24 frames from a video (a photo is used
+            as a single frame) and feeds them to the reconstruction backend on
             the next step.
           </p>
         </header>
@@ -79,8 +80,8 @@ function Capture() {
             </div>
           ) : (
             <div>
-              <p className="text-sm">Drop a video here, or click to pick one</p>
-              <p className="text-xs text-muted-foreground mt-1">mp4 / mov / webm, ≤ 200 MB</p>
+              <p className="text-sm">Drop a video or photo here, or click to pick one</p>
+              <p className="text-xs text-muted-foreground mt-1">mp4 / mov / webm / jpg / png, ≤ 200 MB</p>
             </div>
           )}
         </section>

--- a/frontend/src/routes/p.$projectId.reconstruct.tsx
+++ b/frontend/src/routes/p.$projectId.reconstruct.tsx
@@ -23,7 +23,8 @@ function Reconstruct() {
   const { data: backends = [] } = useBackends();
   const { data: latest } = useLatestReconstruction(projectId);
   const reconstruct = useReconstruct(projectId);
-  const [picked, setPicked] = useState<string>("demo_fixture");
+  const [picked, setPicked] = useState<string>("depth_fusion");
+  const [fov, setFov] = useState<string>("");
 
   const captured = state?.capture.complete ?? false;
   const status = latest?.status ?? "none";
@@ -49,7 +50,7 @@ function Reconstruct() {
             <div>
               <p className="text-sm">Locked.</p>
               <p className="text-xs text-muted-foreground mt-1">
-                {state?.reconstruct.reason ?? "No video uploaded."}
+                {state?.reconstruct.reason ?? "No video or photo uploaded."}
               </p>
               <button
                 onClick={() =>
@@ -94,9 +95,37 @@ function Reconstruct() {
         />
       </div>
 
+      {picked === "depth_fusion" && (
+        <div className="mt-4">
+          <label className="mono text-[11px] uppercase tracking-wider text-muted-foreground">
+            FOV override (optional)
+          </label>
+          <div className="mt-1 flex items-center gap-2">
+            <input
+              type="number"
+              min="40"
+              max="120"
+              step="1"
+              value={fov}
+              disabled={running}
+              onChange={(e) => setFov(e.target.value)}
+              placeholder="auto"
+              className="w-24 bg-background border border-border rounded-sm px-2 py-1 text-sm mono disabled:opacity-50"
+            />
+            <span className="text-xs text-muted-foreground">
+              degrees — leave blank to auto-estimate (Depth-Pro)
+            </span>
+          </div>
+        </div>
+      )}
+
       <button
         disabled={running || reconstruct.isPending}
-        onClick={() => reconstruct.mutate({ backend: picked, params: {} })}
+        onClick={() => {
+          const f = parseFloat(fov);
+          const params = Number.isFinite(f) ? { fov_deg: f } : {};
+          reconstruct.mutate({ backend: picked, params });
+        }}
         className="mt-6 px-4 py-2 rounded-sm border-2 border-primary text-primary text-sm font-medium hover:bg-primary/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
       >
         {running
@@ -148,6 +177,21 @@ function Reconstruct() {
                   ran in {latest.elapsed_s.toFixed(1)}s
                 </span>
               )}
+              {(() => {
+                const p = latest.params ?? {};
+                const nFrames = Number(p.n_frames);
+                if (!Number.isFinite(nFrames)) return null;
+                const nFused = Number(p.n_fused);
+                const avgInliers = Number(p.avg_inliers);
+                return (
+                  <span className="text-xs text-muted-foreground mono">
+                    fused {Number.isFinite(nFused) ? nFused : "?"}/{nFrames - 1} frames
+                    {Number.isFinite(avgInliers) ? ` · avg ${avgInliers.toFixed(0)} inliers` : ""}
+                    {p.depth_model ? ` · ${String(p.depth_model)}` : ""}
+                    {Number.isFinite(Number(p.fov_deg)) ? ` · ${Number(p.fov_deg).toFixed(0)}° fov` : ""}
+                  </span>
+                );
+              })()}
               <button
                 onClick={() =>
                   navigate({ to: "/p/$projectId/validate", params: { projectId } })


### PR DESCRIPTION
## What & why
Real reconstruction (`depth_fusion`) produced a black screen. Root cause: the server port had diverged from matthew's working prototype (`prototype/v4.2.html`). Fixed the port and surfaced failures in the UI; the pipeline already handled video (frame sampling) and photos — now it actually works on both.

## Root cause (the big one)
`match_lightglue` mis-read the fabio-sim LightGlue ONNX output: it treated `matches0` (shape `[1, N]`, a per-keypoint assignment array where each entry is the matched index in image B or -1) as `(M,2)` index pairs. So `matches.shape[0]` was the batch dim (1) `< 8`, and **every frame was rejected as "<8 matches"** → 0 fusions → a ~100M-face pile of unaligned frames marked `ok`. Converting the assignment array to explicit pairs takes a sample pan from **0/7 → 7/7 fused (avg ~569 inliers/frame)**.

## Also fixed (fidelity to v4.2)
- **Intrinsics:** use Depth-Pro's per-frame estimated FOV (median across frames) instead of a hardcoded 60°; default depth model `pro`, falling back to the light `indoor` model on load failure.
- **Depth calibration:** scale-only median ratio (offset c=0), matching the prototype.
- **SuperPoint:** preprocess at 1536px / multiples of 8 (was 512px) for denser, matchable keypoints.
- **Degenerate guard:** with >1 frame and 0 fusions, fail with a clear message instead of emitting a giant unaligned mesh.
- **Mesh budget:** decimate to a total ~1.8M-vertex budget spread across frames, so the PLY stays renderable at any frame count (was ~300MB at 24 frames).

## Frontend
- MeshViewer shows explicit loading / error / empty states (no more silent black canvas).
- Right panel surfaces running / failed reconstruction states.
- Reconstruct page defaults to `depth_fusion`, shows fusion stats, and has an optional FOV override.
- Capture copy accepts photos as well as videos.

## Verification
- Unit tests green (`backend/.venv/bin/pytest tests/test_depth_fusion_geometry.py` — 11 passed).
- In-process E2E on a sampled pan: 7/7 frames fused, avg ~569 inliers, valid binary colored PLY (1.8M verts / 3.59M faces / 75MB), loads via trimesh/PLYLoader.
- Note: first real run downloads Depth-Pro (~1.9GB) and runs on MPS. The live browser round-trip wasn't re-confirmed this session because Docker/Postgres was unstable on the dev machine (infra, not code).