### PR TITLE
Fix reconstruction (faithful prototype port) + photo/video support

### DIFF
--- a/frontend/src/components/MeshViewer.tsx
+++ b/frontend/src/components/MeshViewer.tsx
@@ -81,7 +81,7 @@ export function MeshViewer({ url, className }: { url: string; className?: string
         setLoad(
           geom.getAttribute("position")?.count
             ? { state: "ready" }
-            : { state: "error", msg: "The reconstruction produced an empty mesh." },
+            : { state: "error", msg: "The 3D scene came out empty. Try a clip with more overlap and detail." },
         );
       },
       undefined,
@@ -89,7 +89,7 @@ export function MeshViewer({ url, className }: { url: string; className?: string
         console.error("PLY load failed", err);
         setLoad({
           state: "error",
-          msg: "Couldn't load the reconstruction mesh — it may be missing or failed to generate.",
+          msg: "Couldn't load the 3D scene — it may be missing or failed to generate.",
         });
       },
     );
@@ -139,11 +139,11 @@ export function MeshViewer({ url, className }: { url: string; className?: string
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none p-6 text-center">
           {load.state === "loading" ? (
             <span className="mono text-xs text-muted-foreground animate-pulse">
-              loading mesh…
+              Loading 3D scene…
             </span>
           ) : (
             <span className="mono text-xs text-[var(--status-fail)] max-w-xs">
-              {load.msg ?? "Couldn't load the reconstruction mesh."}
+              {load.msg ?? "Couldn't load the 3D scene."}
             </span>
           )}
         </div>

--- a/frontend/src/components/ProjectRightPanel.tsx
+++ b/frontend/src/components/ProjectRightPanel.tsx
@@ -45,16 +45,17 @@ function RightPaneForProject({ projectId }: { projectId: string }) {
       ) : (
         <div className="w-full h-full border border-dashed border-border/60 rounded-sm flex items-center justify-center text-center px-6 text-xs mono">
           {status === "running" || status === "pending" ? (
-            <span className="text-muted-foreground animate-pulse">
-              reconstructing… the scene will appear here when it finishes
+            <span className="text-muted-foreground max-w-xs animate-pulse">
+              Building your 3D scene… this usually takes a minute or two and
+              appears here automatically when it's ready.
             </span>
           ) : status === "failed" ? (
             <span className="text-[var(--status-fail)] max-w-xs">
-              reconstruction failed: {recon?.error ?? "unknown error"}
+              Reconstruction didn't finish: {recon?.error ?? "something went wrong."}
             </span>
           ) : (
-            <span className="text-muted-foreground">
-              no mesh yet — finish Reconstruct to see the scene here
+            <span className="text-muted-foreground max-w-xs">
+              No 3D scene yet — run Reconstruct to generate one.
             </span>
           )}
         </div>

--- a/frontend/src/routes/p.$projectId.reconstruct.tsx
+++ b/frontend/src/routes/p.$projectId.reconstruct.tsx
@@ -197,7 +197,8 @@ function Reconstruct() {
           )}
           {running && (
             <p className="text-xs text-muted-foreground mono">
-              Running on Inngest · live polling
+              Working on it — this can take a minute or two. The 3D scene shows
+              on the right when it's ready; this page updates on its own.
             </p>
           )}
           {latest.status === "ok" && (

--- a/frontend/src/routes/p.$projectId.reconstruct.tsx
+++ b/frontend/src/routes/p.$projectId.reconstruct.tsx
@@ -24,6 +24,7 @@ function Reconstruct() {
   const { data: latest } = useLatestReconstruction(projectId);
   const reconstruct = useReconstruct(projectId);
   const [picked, setPicked] = useState<string>("depth_fusion");
+  const [depthModel, setDepthModel] = useState<string>("pro");
   const [fov, setFov] = useState<string>("");
 
   const captured = state?.capture.complete ?? false;
@@ -97,6 +98,33 @@ function Reconstruct() {
 
       {picked === "depth_fusion" && (
         <div className="mt-4">
+          <div className="mono text-[11px] uppercase tracking-wider text-muted-foreground mb-2">
+            Depth model
+          </div>
+          <RadioCardGroup
+            name="depth-model"
+            value={depthModel}
+            onValueChange={setDepthModel}
+            disabled={running}
+            options={[
+              {
+                value: "pro",
+                label: "Depth-Pro",
+                tag: "quality",
+                sublabel: "metric + auto-FOV · ~1.9GB, slower first run",
+              },
+              {
+                value: "indoor",
+                label: "Indoor",
+                sublabel: "lighter & faster · uses FOV below",
+              },
+            ]}
+          />
+        </div>
+      )}
+
+      {picked === "depth_fusion" && (
+        <div className="mt-4">
           <label className="mono text-[11px] uppercase tracking-wider text-muted-foreground">
             FOV override (optional)
           </label>
@@ -113,7 +141,7 @@ function Reconstruct() {
               className="w-24 bg-background border border-border rounded-sm px-2 py-1 text-sm mono disabled:opacity-50"
             />
             <span className="text-xs text-muted-foreground">
-              degrees — leave blank to auto-estimate (Depth-Pro)
+              degrees — blank = auto-estimate (Depth-Pro) or 60° (Indoor)
             </span>
           </div>
         </div>
@@ -123,7 +151,9 @@ function Reconstruct() {
         disabled={running || reconstruct.isPending}
         onClick={() => {
           const f = parseFloat(fov);
-          const params = Number.isFinite(f) ? { fov_deg: f } : {};
+          const params: Record<string, unknown> =
+            picked === "depth_fusion" ? { depth_model: depthModel } : {};
+          if (Number.isFinite(f)) params.fov_deg = f;
           reconstruct.mutate({ backend: picked, params });
         }}
         className="mt-6 px-4 py-2 rounded-sm border-2 border-primary text-primary text-sm font-medium hover:bg-primary/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"


### PR DESCRIPTION
## What & why
Real reconstruction (`depth_fusion`) produced a black screen. Root cause: the server port had diverged from matthew's working prototype (`prototype/v4.2.html`). This fixes the port, makes it work on **video and photos**, lets the user pick the depth model, and surfaces progress/failures in the UI.

## Root cause (the big one)
`match_lightglue` mis-read the fabio-sim LightGlue ONNX output: it treated `matches0` (shape `[1, N]`, a per-keypoint assignment array — index of the match in image B, or -1) as `(M,2)` index pairs. So `matches.shape[0]` was the batch dim (1) `< 8`, and **every frame was rejected as "<8 matches"** → 0 fusions → a ~100M-face pile of unaligned frames marked `ok`. Converting the assignment array to explicit pairs takes a sample pan from **0/7 → 7/7 fused (avg ~569 inliers/frame)**.

## Also fixed (fidelity to v4.2)
- **Intrinsics:** use Depth-Pro's per-frame estimated FOV (median across frames) instead of a hardcoded 60°.
- **Depth model:** default `pro` (Depth-Pro, metric + FOV), falling back to the light `indoor` model on load failure — and **selectable in the UI**.
- **Depth calibration:** scale-only median ratio (offset c=0), matching the prototype.
- **SuperPoint:** preprocess at 1536px / multiples of 8 (was 512px) for denser, matchable keypoints.
- **Degenerate guard:** with >1 frame and 0 fusions, fail with a clear message instead of emitting a giant unaligned mesh.
- **Mesh budget:** decimate to a total ~1.8M-vertex budget spread across frames, so the PLY stays renderable at any frame count (was ~300MB at 24 frames).

## Frontend
- Viewer + right panel show loading / building / failed / empty states (no more silent black canvas), with friendly, architecture-agnostic copy.
- Reconstruct page defaults to `depth_fusion`, adds a **Depth model picker** (Depth-Pro vs Indoor) and an optional FOV override, and shows fusion stats.
- Capture copy accepts photos as well as videos.

## Verification
- Unit tests green (`backend/.venv/bin/pytest tests/test_depth_fusion_geometry.py` — 11 passed).
- **Live end-to-end** through the running stack: upload → reconstruct → 7/7 frames fused (~569 avg inliers) in ~19s (indoor), mesh served over HTTP (200, valid binary colored PLY).
- Note: first run with Depth-Pro downloads ~1.9GB and runs on MPS.