### PR TITLE
Adjust placement (move/orient/scale) + Y-up orientation fix

### DIFF
--- a/backend/src/features/reconstruction/backends/depth_fusion.py
+++ b/backend/src/features/reconstruction/backends/depth_fusion.py
@@ -336,6 +336,14 @@ class DepthFusionBackend(ReconstructionBackend):
         colors = np.concatenate(all_colors, axis=0)
         faces = np.concatenate(all_faces, axis=0)
 
+        # back_project works in OpenCV camera axes (X right, Y down, Z forward).
+        # The viewer and the downstream physics build both expect Y up, so flip
+        # the whole scene into that convention (matches prototype/v4.2). Negating
+        # Y *and* Z is a 180° rotation about X — it preserves face winding, so no
+        # normals/winding fix is needed.
+        verts[:, 1] *= -1.0
+        verts[:, 2] *= -1.0
+
         mesh_path = out_dir / "mesh.ply"
         points_path = out_dir / "points.ply"
         _write_ply_mesh(verts, faces, colors, mesh_path)

--- a/backend/src/features/reconstruction/router.py
+++ b/backend/src/features/reconstruction/router.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import inngest
 from fastapi import APIRouter, BackgroundTasks, File, HTTPException, UploadFile
 from nanoid import generate as nanoid
+from pydantic import BaseModel
 from sqlalchemy import select
 
 from src.config import get_settings
@@ -183,3 +184,54 @@ def latest_reconstruction(project: ProjectDep, db: DbSession) -> Reconstruction 
         .where(Reconstruction.project_id == project.id)
         .order_by(Reconstruction.created_at.desc())
     ).first()
+
+
+class MeshTransformRequest(BaseModel):
+    # 16 floats, column-major (THREE.Matrix4.elements). Maps the raw mesh coords
+    # to the placement the user arranged in the viewer, so we can bake it in.
+    matrix: list[float]
+
+
+@router.post(
+    "/projects/{project_id}/reconstruction/transform",
+    response_model=ReconstructionOut,
+)
+def transform_reconstruction(
+    project: ProjectDep, db: DbSession, body: MeshTransformRequest
+) -> Reconstruction:
+    """Bake a rigid+scale placement (rotate / move / scale) into the latest
+    reconstruction's mesh + point cloud, in place, so the downstream Build step
+    uses the corrected environment. The transform is computed client-side in the
+    viewer and passed as a 4x4 matrix — what you see is what gets baked."""
+    recon = db.scalars(
+        select(Reconstruction)
+        .where(Reconstruction.project_id == project.id, Reconstruction.status == "ok")
+        .order_by(Reconstruction.created_at.desc())
+    ).first()
+    if recon is None or not recon.mesh_path:
+        raise HTTPException(400, "no reconstruction mesh to transform")
+    if len(body.matrix) != 16:
+        raise HTTPException(422, "matrix must have 16 elements (column-major 4x4)")
+
+    import numpy as np
+    import trimesh
+
+    # THREE.Matrix4.elements is column-major; numpy/trimesh want row-major.
+    M = np.array(body.matrix, dtype=np.float64).reshape(4, 4).T
+
+    mesh_path = Path(recon.mesh_path)
+    if not mesh_path.exists():
+        raise HTTPException(404, "mesh file missing on disk")
+
+    # Apply to the mesh and (if present) the matching point cloud.
+    for p in (mesh_path, mesh_path.with_name("points.ply")):
+        if not p.exists():
+            continue
+        geom = trimesh.load(p, process=False)
+        geom.apply_transform(M)
+        geom.export(p)
+
+    recon.params = {**(recon.params or {}), "placement_applied": True}
+    db.commit()
+    db.refresh(recon)
+    return recon

--- a/frontend/src/components/MeshViewer.tsx
+++ b/frontend/src/components/MeshViewer.tsx
@@ -1,7 +1,9 @@
 /**
  * Vanilla three.js mesh viewer. No drei / no react-three-fiber so it works
- * cleanly under React 19. Loads a .ply, centers and normalizes it, gives
- * the user OrbitControls + a faint grid floor + a directional light.
+ * cleanly under React 19. Loads a .ply and frames the camera to it (the mesh
+ * is kept in real coordinates so an editable placement transform — rotate /
+ * move / scale, applied about the mesh centre — previews exactly what gets
+ * baked into the file). Gives the user OrbitControls + a grid floor + lights.
  */
 import { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
@@ -10,33 +12,87 @@ import { PLYLoader } from "three/examples/jsm/loaders/PLYLoader.js";
 
 import { cn } from "@/lib/utils";
 
+export type Placement = {
+  rx: number; // rotation degrees about X
+  ry: number;
+  rz: number;
+  tx: number; // translation (world units)
+  ty: number;
+  tz: number;
+  scale: number; // uniform scale (>0)
+};
+
+export const IDENTITY_PLACEMENT: Placement = {
+  rx: 0, ry: 0, rz: 0, tx: 0, ty: 0, tz: 0, scale: 1,
+};
+
 type LoadState = { state: "loading" | "ready" | "error"; msg?: string };
 
-export function MeshViewer({ url, className }: { url: string; className?: string }) {
+/** Placement matrix that rotates & scales about `center`, then translates. */
+function placementMatrix(p: Placement, center: THREE.Vector3): THREE.Matrix4 {
+  const euler = new THREE.Euler(
+    THREE.MathUtils.degToRad(p.rx),
+    THREE.MathUtils.degToRad(p.ry),
+    THREE.MathUtils.degToRad(p.rz),
+    "XYZ",
+  );
+  const R = new THREE.Matrix4().makeRotationFromEuler(euler);
+  const S = new THREE.Matrix4().makeScale(p.scale, p.scale, p.scale);
+  const toOrigin = new THREE.Matrix4().makeTranslation(-center.x, -center.y, -center.z);
+  const back = new THREE.Matrix4().makeTranslation(center.x, center.y, center.z);
+  const T = new THREE.Matrix4().makeTranslation(p.tx, p.ty, p.tz);
+  // M = T · back · R · S · toOrigin  (apply rightmost first)
+  return new THREE.Matrix4()
+    .multiply(T)
+    .multiply(back)
+    .multiply(R)
+    .multiply(S)
+    .multiply(toOrigin);
+}
+
+export function MeshViewer({
+  url,
+  className,
+  placement = IDENTITY_PLACEMENT,
+  onMatrix,
+}: {
+  url: string;
+  className?: string;
+  placement?: Placement;
+  onMatrix?: (elements: number[]) => void;
+}) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [load, setLoad] = useState<LoadState>({ state: "loading" });
+  // Live handles shared between the load effect and the placement effect.
+  const envRef = useRef<{ group: THREE.Group; center: THREE.Vector3 } | null>(null);
+  const placementRef = useRef(placement);
+  placementRef.current = placement;
+  const applyPlacementRef = useRef<(() => void) | null>(null);
+  const onMatrixRef = useRef(onMatrix);
+  onMatrixRef.current = onMatrix;
 
+  // Scene setup + mesh load — re-runs only when the URL changes.
   useEffect(() => {
     const container = containerRef.current;
     if (!container || !url) return;
     setLoad({ state: "loading" });
+    envRef.current = null;
 
     const width = container.clientWidth || 800;
     const height = container.clientHeight || 600;
 
     const scene = new THREE.Scene();
     scene.background = new THREE.Color(0x0a0a0a);
-    scene.fog = new THREE.Fog(0x0a0a0a, 18, 35);
 
-    const camera = new THREE.PerspectiveCamera(45, width / height, 0.05, 200);
-    camera.position.set(5, 4, 5);
+    const camera = new THREE.PerspectiveCamera(45, width / height, 0.01, 2000);
+    camera.position.set(4, 3, 4);
 
     const renderer = new THREE.WebGLRenderer({ antialias: true });
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     renderer.setSize(width, height);
     container.appendChild(renderer.domElement);
 
-    scene.add(new THREE.AmbientLight(0xffffff, 0.35));
+    scene.add(new THREE.AmbientLight(0xffffff, 0.4));
     const sun = new THREE.DirectionalLight(0xffffff, 0.95);
     sun.position.set(8, 12, 6);
     scene.add(sun);
@@ -52,47 +108,64 @@ export function MeshViewer({ url, className }: { url: string; className?: string
     const controls = new OrbitControls(camera, renderer.domElement);
     controls.enableDamping = true;
     controls.dampingFactor = 0.08;
-    controls.target.set(0, 0.5, 0);
 
-    let mesh: THREE.Mesh | null = null;
+    const envGroup = new THREE.Group();
+    envGroup.matrixAutoUpdate = false;
+    scene.add(envGroup);
+
     const loader = new PLYLoader();
     loader.load(
       url,
       (geom) => {
+        if (!geom.getAttribute("position")?.count) {
+          setLoad({ state: "error", msg: "The 3D scene came out empty. Try a clip with more overlap and detail." });
+          return;
+        }
         geom.computeVertexNormals();
-        geom.center();
-        // Auto-scale: fit longest dim to ~4 world units
-        const bbox = new THREE.Box3().setFromBufferAttribute(
-          geom.getAttribute("position") as THREE.BufferAttribute,
-        );
-        const size = bbox.getSize(new THREE.Vector3());
-        const longest = Math.max(size.x, size.y, size.z);
-        const scale = longest > 0 ? 4 / longest : 1;
+        geom.computeBoundingBox();
+        geom.computeBoundingSphere();
+        const center = geom.boundingBox!.getCenter(new THREE.Vector3());
+        const radius = geom.boundingSphere?.radius || 1;
+
         const material = new THREE.MeshStandardMaterial({
           color: 0xdcdcdc,
           roughness: 0.55,
           metalness: 0.05,
           side: THREE.DoubleSide,
+          vertexColors: !!geom.getAttribute("color"),
         });
-        mesh = new THREE.Mesh(geom, material);
-        mesh.scale.setScalar(scale);
-        mesh.position.y = (size.y * scale) / 2;
-        scene.add(mesh);
-        setLoad(
-          geom.getAttribute("position")?.count
-            ? { state: "ready" }
-            : { state: "error", msg: "The 3D scene came out empty. Try a clip with more overlap and detail." },
-        );
+        const mesh = new THREE.Mesh(geom, material);
+        envGroup.add(mesh);
+        envRef.current = { group: envGroup, center };
+
+        // Frame the camera to the mesh and orbit around its centre.
+        const dist = (radius / Math.sin(THREE.MathUtils.degToRad(camera.fov) / 2)) * 1.3;
+        camera.position.copy(center).add(new THREE.Vector3(1, 0.7, 1).normalize().multiplyScalar(dist));
+        camera.far = Math.max(2000, dist * 50);
+        camera.updateProjectionMatrix();
+        controls.target.copy(center);
+        controls.update();
+
+        applyPlacement();
+        setLoad({ state: "ready" });
       },
       undefined,
       (err) => {
         console.error("PLY load failed", err);
-        setLoad({
-          state: "error",
-          msg: "Couldn't load the 3D scene — it may be missing or failed to generate.",
-        });
+        setLoad({ state: "error", msg: "Couldn't load the 3D scene — it may be missing or failed to generate." });
       },
     );
+
+    // Applies the latest placement prop to the loaded group + reports the matrix.
+    function applyPlacement() {
+      const env = envRef.current;
+      if (!env) return;
+      const M = placementMatrix(placementRef.current, env.center);
+      env.group.matrix.copy(M);
+      env.group.matrixWorldNeedsUpdate = true;
+      onMatrixRef.current?.(M.elements.slice());
+    }
+    applyPlacementRef.current = applyPlacement;
 
     let rafId = 0;
     const tick = () => {
@@ -117,15 +190,19 @@ export function MeshViewer({ url, className }: { url: string; className?: string
       ro.disconnect();
       controls.dispose();
       renderer.dispose();
-      if (mesh) {
-        mesh.geometry.dispose();
-        (mesh.material as THREE.Material).dispose();
-      }
+      envRef.current = null;
+      applyPlacementRef.current = null;
       if (renderer.domElement.parentNode === container) {
         container.removeChild(renderer.domElement);
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [url]);
+
+  // Re-apply placement live when it changes (no mesh reload).
+  useEffect(() => {
+    applyPlacementRef.current?.();
+  }, [placement]);
 
   return (
     <div

--- a/frontend/src/components/ProjectRightPanel.tsx
+++ b/frontend/src/components/ProjectRightPanel.tsx
@@ -4,12 +4,15 @@
  * Reconstruct / Validate / Build / Train / Replay.
  *
  * Reads the current project id from the route match, fetches the latest
- * successful reconstruction, and shows the mesh (or a placeholder).
+ * successful reconstruction, shows the mesh (or a placeholder), and lets the
+ * user rotate / move / scale the environment and bake that placement into the
+ * mesh so the downstream Build step uses the corrected scene.
  */
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useMatches } from "@tanstack/react-router";
 
-import { MeshViewer } from "@/components/MeshViewer";
-import { useLatestReconstruction } from "@/lib/api";
+import { IDENTITY_PLACEMENT, MeshViewer, type Placement } from "@/components/MeshViewer";
+import { useApplyReconstructionTransform, useLatestReconstruction } from "@/lib/api";
 
 export function ProjectRightPanel() {
   const matches = useMatches();
@@ -29,38 +32,196 @@ export function ProjectRightPanel() {
   return <RightPaneForProject projectId={projectId} />;
 }
 
+function isIdentity(p: Placement): boolean {
+  return (
+    p.rx === 0 && p.ry === 0 && p.rz === 0 &&
+    p.tx === 0 && p.ty === 0 && p.tz === 0 &&
+    p.scale === 1
+  );
+}
+
 function RightPaneForProject({ projectId }: { projectId: string }) {
   const { data: recon } = useLatestReconstruction(projectId);
+  const apply = useApplyReconstructionTransform(projectId);
+
+  const [placement, setPlacement] = useState<Placement>(IDENTITY_PLACEMENT);
+  const [meshBump, setMeshBump] = useState(0);
+  const matrixRef = useRef<number[]>([]);
 
   const status = recon?.status;
+  const reconId = recon?.id;
+
+  // A new reconstruction (or freshly baked mesh) → start from a clean placement.
+  useEffect(() => {
+    setPlacement(IDENTITY_PLACEMENT);
+  }, [reconId]);
+
   const meshUrl =
     recon?.mesh_path && status === "ok"
-      ? meshPathToUrl(recon.mesh_path, projectId)
+      ? `${meshPathToUrl(recon.mesh_path, projectId)}?v=${reconId}_${meshBump}`
       : null;
 
+  const onApply = async () => {
+    if (!matrixRef.current.length) return;
+    try {
+      await apply.mutateAsync(matrixRef.current);
+      setPlacement(IDENTITY_PLACEMENT); // baked in — reset the live transform
+      setMeshBump((n) => n + 1); // reload the re-exported mesh
+    } catch {
+      /* surfaced via apply.isError below */
+    }
+  };
+
   return (
-    <aside className="hidden lg:flex flex-1 overflow-hidden p-4 border-l border-border">
-      {meshUrl ? (
-        <MeshViewer url={meshUrl} />
-      ) : (
-        <div className="w-full h-full border border-dashed border-border/60 rounded-sm flex items-center justify-center text-center px-6 text-xs mono">
-          {status === "running" || status === "pending" ? (
-            <span className="text-muted-foreground max-w-xs animate-pulse">
-              Building your 3D scene… this usually takes a minute or two and
-              appears here automatically when it's ready.
-            </span>
-          ) : status === "failed" ? (
-            <span className="text-[var(--status-fail)] max-w-xs">
-              Reconstruction didn't finish: {recon?.error ?? "something went wrong."}
-            </span>
-          ) : (
-            <span className="text-muted-foreground max-w-xs">
-              No 3D scene yet — run Reconstruct to generate one.
-            </span>
-          )}
-        </div>
+    <aside className="hidden lg:flex flex-col flex-1 overflow-hidden p-4 border-l border-border gap-3">
+      <div className="flex-1 min-h-0">
+        {meshUrl ? (
+          <MeshViewer
+            url={meshUrl}
+            placement={placement}
+            onMatrix={(m) => {
+              matrixRef.current = m;
+            }}
+          />
+        ) : (
+          <div className="w-full h-full border border-dashed border-border/60 rounded-sm flex items-center justify-center text-center px-6 text-xs mono">
+            {status === "running" || status === "pending" ? (
+              <span className="text-muted-foreground max-w-xs animate-pulse">
+                Building your 3D scene… this usually takes a minute or two and
+                appears here automatically when it's ready.
+              </span>
+            ) : status === "failed" ? (
+              <span className="text-[var(--status-fail)] max-w-xs">
+                Reconstruction didn't finish: {recon?.error ?? "something went wrong."}
+              </span>
+            ) : (
+              <span className="text-muted-foreground max-w-xs">
+                No 3D scene yet — run Reconstruct to generate one.
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {meshUrl && (
+        <PlacementControls
+          placement={placement}
+          onChange={setPlacement}
+          onReset={() => setPlacement(IDENTITY_PLACEMENT)}
+          onApply={onApply}
+          applying={apply.isPending}
+          error={apply.isError}
+          dirty={!isIdentity(placement)}
+        />
       )}
     </aside>
+  );
+}
+
+function PlacementControls({
+  placement,
+  onChange,
+  onReset,
+  onApply,
+  applying,
+  error,
+  dirty,
+}: {
+  placement: Placement;
+  onChange: (p: Placement) => void;
+  onReset: () => void;
+  onApply: () => void;
+  applying: boolean;
+  error: boolean;
+  dirty: boolean;
+}) {
+  const set = (k: keyof Placement, v: number) => onChange({ ...placement, [k]: v });
+
+  return (
+    <div className="border border-border rounded-sm p-3 text-xs flex flex-col gap-2 max-h-[42%] overflow-auto">
+      <div className="flex items-center justify-between">
+        <span className="mono text-[11px] uppercase tracking-wider text-muted-foreground">
+          Adjust placement
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onReset}
+            disabled={!dirty || applying}
+            className="px-2 py-0.5 rounded-sm border border-border hover:bg-accent disabled:opacity-40"
+          >
+            Reset
+          </button>
+          <button
+            onClick={onApply}
+            disabled={!dirty || applying}
+            className="px-2 py-0.5 rounded-sm bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-40"
+          >
+            {applying ? "Applying…" : "Apply"}
+          </button>
+        </div>
+      </div>
+
+      <Group label="Rotate °">
+        <Row label="X" value={placement.rx} min={-180} max={180} step={1} onChange={(v) => set("rx", v)} fmt={(v) => `${v}°`} />
+        <Row label="Y" value={placement.ry} min={-180} max={180} step={1} onChange={(v) => set("ry", v)} fmt={(v) => `${v}°`} />
+        <Row label="Z" value={placement.rz} min={-180} max={180} step={1} onChange={(v) => set("rz", v)} fmt={(v) => `${v}°`} />
+      </Group>
+
+      <Group label="Move">
+        <Row label="X" value={placement.tx} min={-5} max={5} step={0.05} onChange={(v) => set("tx", v)} fmt={(v) => v.toFixed(2)} />
+        <Row label="Y" value={placement.ty} min={-5} max={5} step={0.05} onChange={(v) => set("ty", v)} fmt={(v) => v.toFixed(2)} />
+        <Row label="Z" value={placement.tz} min={-5} max={5} step={0.05} onChange={(v) => set("tz", v)} fmt={(v) => v.toFixed(2)} />
+      </Group>
+
+      <Group label="Scale">
+        <Row label="×" value={placement.scale} min={0.1} max={3} step={0.05} onChange={(v) => set("scale", v)} fmt={(v) => `${v.toFixed(2)}×`} />
+      </Group>
+
+      <p className="text-[10px] text-muted-foreground/80 leading-snug">
+        Apply bakes this into the scene used for Build. Rotate/scale pivot around
+        the scene's centre.
+      </p>
+      {error && (
+        <p className="text-[10px] text-[var(--status-fail)]">Couldn't apply — please try again.</p>
+      )}
+    </div>
+  );
+}
+
+function Group({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-[10px] text-muted-foreground/70 mono">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+function Row({
+  label, value, min, max, step, onChange, fmt,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (v: number) => void;
+  fmt: (v: number) => string;
+}) {
+  return (
+    <label className="flex items-center gap-2">
+      <span className="w-3 text-muted-foreground mono">{label}</span>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        className="flex-1 accent-[var(--primary)] h-1"
+      />
+      <span className="w-12 text-right mono text-muted-foreground tabular-nums">{fmt(value)}</span>
+    </label>
   );
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -272,6 +272,23 @@ export const useReconstruct = (projectId: string) => {
   });
 };
 
+export const useApplyReconstructionTransform = (projectId: string) => {
+  const qc = useQueryClient();
+  return useMutation({
+    // `matrix` is the viewer's 4x4 placement (column-major, THREE.Matrix4.elements).
+    mutationFn: (matrix: number[]) =>
+      send<Reconstruction>(
+        `/api/projects/${projectId}/reconstruction/transform`,
+        "POST",
+        { matrix },
+      ),
+    onSuccess: (updated) => {
+      qc.setQueryData(["reconstruction", projectId], updated);
+      qc.invalidateQueries({ queryKey: ["reconstruction", projectId] });
+    },
+  });
+};
+
 export const useLatestReconstruction = (projectId: string) => {
   const qc = useQueryClient();
   return useQuery({


### PR DESCRIPTION
Follow-up to #27 (already merged). Two changes that landed after that merge:

## Y-up orientation fix
The back-projection works in OpenCV axes (Y down); the viewer and the physics Build both expect Y up, so reconstructions rendered **upside down**. Flip Y and Z on the final mesh (180° about X — preserves face winding), matching the prototype. Now correct for the viewer *and* downstream Build.

## Move / orient / scale the reconstructed environment
New placement controls in the scene panel so the environment can be re-seated, not just viewed:
- **Rotate X/Y/Z**, **Move X/Y/Z**, **uniform Scale** sliders, plus **Reset** and **Apply**.
- The viewer previews the transform live (pivoting about the scene centre) and reports the 4×4 matrix.
- **Apply** POSTs that matrix to a new `POST /api/projects/{id}/reconstruction/transform` endpoint that bakes it into `mesh.ply` + `points.ply` in place — so the downstream **Build/physics** step uses the corrected environment. What you see is what gets baked; the view reloads the re-exported mesh and the sliders reset.

### Files
- `backend/.../reconstruction/router.py` — transform endpoint (trimesh `apply_transform` + re-export)
- `frontend/.../lib/api.ts` — `useApplyReconstructionTransform`
- `frontend/.../components/MeshViewer.tsx` — editable placement (frames camera instead of normalizing geometry; exports matrix)
- `frontend/.../components/ProjectRightPanel.tsx` — sliders + reset/apply, mesh cache-busting on re-export

### Verification
- Orientation: in-process reconstruction now Y-up (Z bounds negative); a full live run reconstructed 7/7 frames and served the mesh (200).
- Transform: trimesh bake verified in-process (90° rotate swaps extents, faces preserved); frontend typechecks clean.