### PR TITLE
Enclose partial rooms with invisible boundary walls + tolerant Validate

### DIFF
--- a/backend/src/features/builds/inngest_functions.py
+++ b/backend/src/features/builds/inngest_functions.py
@@ -30,6 +30,7 @@ async def build_env(ctx: inngest.Context) -> dict:
     target_diagonal_m: float | None = payload.get("target_diagonal_m")
     max_hulls: int = int(payload.get("max_hulls") or 64)
     up_axis: str = payload.get("up_axis") or "auto"
+    enclose: bool = payload.get("enclose", True)
 
     log.info("build-env: %s", build_id)
 
@@ -62,6 +63,7 @@ async def build_env(ctx: inngest.Context) -> dict:
                 target_diagonal_m=target_diagonal_m or settings.default_target_diagonal_m,
                 up_axis=up_axis,
                 max_hulls=max_hulls,
+                enclose=enclose,
             )
         )
 

--- a/backend/src/features/builds/router.py
+++ b/backend/src/features/builds/router.py
@@ -54,6 +54,7 @@ async def build_project(
                     "target_diagonal_m": body.target_diagonal_m,
                     "max_hulls": body.max_hulls,
                     "up_axis": body.up_axis,
+                    "enclose": body.enclose,
                 },
             )
         ]

--- a/backend/src/features/validation/checks.py
+++ b/backend/src/features/validation/checks.py
@@ -51,9 +51,11 @@ def check_watertight(mesh: trimesh.Trimesh) -> CheckResult:
         )
     return CheckResult(
         "watertight",
-        "fail",
-        f"{closed}/{len(parts)} components closed — mesh has holes",
-        "Single-photo reconstructions are 2.5D and open at the back. Use multi-frame video or LiDAR.",
+        "warn",
+        f"{closed}/{len(parts)} components closed — open/partial scan",
+        "Partial captures (e.g. half a room) are open at the back. Build wraps "
+        "the scene in invisible boundary walls so the agent stays inside; "
+        "multi-frame video or LiDAR gives a more complete mesh.",
     )
 
 
@@ -165,9 +167,11 @@ def check_floor_detected(mesh: trimesh.Trimesh) -> CheckResult:
         )
     return CheckResult(
         "floor_detected",
-        "fail",
-        "no flat ground plane found",
-        "Without a floor, the agent has nowhere to spawn. Record with the camera tilted slightly down.",
+        "warn",
+        "little/no floor captured in the scan",
+        "Build adds a ground plane under the scene, so the agent can still "
+        "spawn — but capturing more floor (camera tilted slightly down) improves "
+        "coverage and the spawn area.",
     )
 
 

--- a/backend/src/schemas/__init__.py
+++ b/backend/src/schemas/__init__.py
@@ -81,6 +81,9 @@ class BuildRequest(BaseModel):
     target_diagonal_m: float | None = None
     max_hulls: int | None = None
     up_axis: str = "auto"
+    enclose: bool = True
+    """Wrap the scene in invisible boundary walls so the agent can't leave a
+    partial/open reconstruction."""
 
 
 class Goal3D(BaseModel):

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -173,8 +173,11 @@ export type BuildRow = {
 export const useBuild = (projectId: string) => {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: () =>
-      send<BuildRow>(`/api/projects/${projectId}/build`, "POST", { up_axis: "y" }),
+    mutationFn: (opts?: { enclose?: boolean }) =>
+      send<BuildRow>(`/api/projects/${projectId}/build`, "POST", {
+        up_axis: "y",
+        enclose: opts?.enclose ?? true,
+      }),
     onSuccess: (created) => {
       // Seed the cache with the new pending row so the polling query
       // re-engages immediately instead of holding the previous status=ok.

--- a/frontend/src/routes/p.$projectId.build.tsx
+++ b/frontend/src/routes/p.$projectId.build.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
 
 import { ProjectSceneLayout } from "@/components/ProjectSceneLayout";
 import { StatusDot } from "@/components/StatusDot";
@@ -13,6 +14,7 @@ function BuildScreen() {
   const build = useBuild(projectId);
   const { data: latest } = useLatestBuild(projectId);
   const navigate = useNavigate();
+  const [enclose, setEnclose] = useState(true);
 
   const running = latest?.status === "pending" || latest?.status === "running";
 
@@ -26,10 +28,27 @@ function BuildScreen() {
         </p>
       </header>
 
+      <label className="mt-6 flex items-start gap-2 text-sm max-w-md cursor-pointer">
+        <input
+          type="checkbox"
+          checked={enclose}
+          disabled={running}
+          onChange={(e) => setEnclose(e.target.checked)}
+          className="mt-0.5 accent-[var(--primary)]"
+        />
+        <span>
+          Enclose with invisible boundary walls
+          <span className="block text-xs text-muted-foreground">
+            Keeps the agent inside partial/open scans (e.g. a half-recorded
+            room). Recommended.
+          </span>
+        </span>
+      </label>
+
       <button
         disabled={build.isPending || running}
-        onClick={() => build.mutate()}
-        className="mt-6 px-4 py-2 rounded-sm border-2 border-primary text-primary text-sm font-medium hover:bg-primary/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        onClick={() => build.mutate({ enclose })}
+        className="mt-4 px-4 py-2 rounded-sm border-2 border-primary text-primary text-sm font-medium hover:bg-primary/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
       >
         {running ? "Building…" : build.isPending ? "Queuing…" : latest ? "Re-build env" : "Build env"}
       </button>

--- a/rl_env/rl_env/build.py
+++ b/rl_env/rl_env/build.py
@@ -40,6 +40,15 @@ class BuildConfig:
     """Cap on convex hulls when decomposing. More hulls = more accurate collisions, slower sim."""
     decompose: bool = True
     """If False, use connected-component hulls (fast); skips per-shape decomposition."""
+    enclose: bool = True
+    """Wrap the scene in invisible boundary walls so the agent can't wander out
+    of partial/open reconstructions (a half-recorded room has open sides). The
+    walls sit at the mesh's XY bounds + `wall_margin` and are collidable +
+    lidar-visible but not rendered."""
+    wall_margin: float = 0.25
+    """Gap (meters) between the reconstructed geometry and the boundary walls."""
+    wall_thickness: float = 0.08
+    """Half-thickness (meters) of the invisible boundary walls."""
 
 
 @dataclass
@@ -213,6 +222,10 @@ def write_mjcf(
     out_dir: Path,
     floor_z: float,
     spawn_region: tuple[float, float, float, float],
+    bounds: np.ndarray | None = None,
+    enclose: bool = True,
+    wall_margin: float = 0.25,
+    wall_thickness: float = 0.08,
 ) -> Path:
     mesh_dir = out_dir / "meshes"
     mesh_dir.mkdir(parents=True, exist_ok=True)
@@ -319,6 +332,45 @@ def write_mjcf(
             friction=" ".join(f"{v:.4f}" for v in mat["friction"]),
         )
 
+    # Invisible boundary walls — enclose the navigable footprint so the agent
+    # can't escape a partial/open reconstruction. Sit at the mesh XY bounds +
+    # margin, floor-to-ceiling. Collidable + lidar-visible, but rgba alpha 0 so
+    # they don't render. Named `boundary_*` so NavEnv counts touches as
+    # collisions (see env._collect_scene_geoms).
+    if enclose and bounds is not None:
+        bx0, by0, bz0 = float(bounds[0][0]), float(bounds[0][1]), float(bounds[0][2])
+        bx1, by1, bz1 = float(bounds[1][0]), float(bounds[1][1]), float(bounds[1][2])
+        x0, x1 = bx0 - wall_margin, bx1 + wall_margin
+        y0, y1 = by0 - wall_margin, by1 + wall_margin
+        wall_h = max(bz1 - bz0, 1.0)  # at least 1 m so the agent can't roll over
+        zc = floor_z + wall_h / 2.0
+        cx, cy = (x0 + x1) / 2.0, (y0 + y1) / 2.0
+        hx, hy = (x1 - x0) / 2.0, (y1 - y0) / 2.0
+        t = wall_thickness
+        bf = "1.0 0.005 0.0001"
+        boundary = ET.SubElement(worldbody, "body", name="boundary", pos="0 0 0")
+        walls = [
+            ("boundary_xmin", f"{t} {hy + t} {wall_h / 2:.4f}", f"{x0:.4f} {cy:.4f} {zc:.4f}"),
+            ("boundary_xmax", f"{t} {hy + t} {wall_h / 2:.4f}", f"{x1:.4f} {cy:.4f} {zc:.4f}"),
+            ("boundary_ymin", f"{hx + t} {t} {wall_h / 2:.4f}", f"{cx:.4f} {y0:.4f} {zc:.4f}"),
+            ("boundary_ymax", f"{hx + t} {t} {wall_h / 2:.4f}", f"{cx:.4f} {y1:.4f} {zc:.4f}"),
+        ]
+        for name, size, pos in walls:
+            ET.SubElement(
+                boundary,
+                "geom",
+                name=name,
+                type="box",
+                size=size,
+                pos=pos,
+                contype="1",
+                conaffinity="1",
+                condim="3",
+                group="3",
+                rgba="0 0 0 0",
+                friction=bf,
+            )
+
     xmin, xmax, ymin, ymax = spawn_region
     spawn_x = (xmin + xmax) / 2
     spawn_y = (ymin + ymax) / 2
@@ -415,6 +467,10 @@ def build_environment(cfg: BuildConfig) -> BuildArtifacts:
         out_dir=out_dir,
         floor_z=floor_z,
         spawn_region=spawn_region,
+        bounds=bounds,
+        enclose=cfg.enclose,
+        wall_margin=cfg.wall_margin,
+        wall_thickness=cfg.wall_thickness,
     )
 
     materials = {f"hull_{i:04d}": MATERIAL_TABLE[c] for i, c in enumerate(classes)}

--- a/rl_env/rl_env/env.py
+++ b/rl_env/rl_env/env.py
@@ -112,10 +112,13 @@ class NavEnv(gym.Env):
         )
 
     def _collect_scene_geoms(self) -> set[int]:
+        # Reconstructed hulls *and* the invisible boundary walls count as the
+        # "scene" the agent collides with (so touching a boundary is penalized
+        # like a wall; the agent senses them via lidar too).
         ids: set[int] = set()
         for i in range(self.model.ngeom):
             name = mujoco.mj_id2name(self.model, mujoco.mjtObj.mjOBJ_GEOM, i)
-            if name and name.startswith("hull_"):
+            if name and (name.startswith("hull_") or name.startswith("boundary_")):
                 ids.add(i)
         return ids
 


### PR DESCRIPTION
Make partial/open reconstructions (e.g. someone records *half* a room) usable for RL nav.

## Problem
- **No containment:** Build decomposes the mesh into collision hulls and drops a 20×20 ground plane, but adds no enclosing walls, and the nav env has no out-of-bounds rule. A half-room scan "builds," but the agent just walks out the open side onto the bare floor.
- **Validate hard-fails it:** `check_watertight` fails open meshes, discouraging exactly this common case.

## Changes
- **Invisible boundary walls (rl_env/build.py):** `BuildConfig.enclose` (default on) wraps the scene in 4 transparent collision walls at the mesh XY bounds + margin, floor-to-ceiling. Collidable and lidar-visible (so the agent can sense them) but `rgba` alpha 0 so they don't render. Named `boundary_*`.
- **env.py:** `_collect_scene_geoms` now includes `boundary_*`, so touching a boundary is penalized like a wall.
- **Tolerant Validate (validation/checks.py):** `watertight` and `floor_detected` downgraded from **fail → warn** for open/partial scans, with messages explaining that Build encloses them and the sim always adds a ground plane. Partial rooms now pass through (overall = warn, no hard fail) instead of being blocked.
- **Plumbing + UI:** `enclose` flows `BuildRequest → inngest → BuildConfig`; a default-on "Enclose with invisible boundary walls" checkbox on the Build page.

## Verification
- Built the sample room with enclosure: `scene.xml` contains the 4 `boundary_*` geoms, MuJoCo loads the scene, and `NavEnv` counts them (17 scene geoms incl. 4 boundary).
- Ran the validation catalog on a real open reconstruction: **overall = WARN, zero hard-fails** (watertight + floor are warn; the rest pass). Previously this hard-failed on watertightness.
- Backend compiles; frontend typechecks clean.