### PR TITLE
Cancel button on each pipeline step

### DIFF
--- a/backend/src/features/builds/inngest_functions.py
+++ b/backend/src/features/builds/inngest_functions.py
@@ -40,6 +40,8 @@ async def build_env(ctx: inngest.Context) -> dict:
             b = db.get(Build, build_id)
             if b is None:
                 raise RuntimeError(f"build {build_id} disappeared")
+            if b.status == "cancelled":
+                return {"build_id": build_id, "cancelled": True}
             b.status = "running"
             db.commit()
             recon = (
@@ -70,6 +72,8 @@ async def build_env(ctx: inngest.Context) -> dict:
         with SessionLocal() as db:
             b = db.get(Build, build_id)
             assert b is not None
+            if b.status == "cancelled":  # cancelled mid-build — discard result
+                return {"build_id": build_id, "cancelled": True}
             b.mjcf_path = str(artifacts.mjcf_path)
             b.n_hulls = artifacts.n_hulls
             b.bounds = {

--- a/backend/src/features/builds/router.py
+++ b/backend/src/features/builds/router.py
@@ -70,3 +70,21 @@ def latest_build(project: ProjectDep, db: DbSession) -> Build | None:
         .where(Build.project_id == project.id)
         .order_by(Build.created_at.desc())
     ).first()
+
+
+@router.post("/{project_id}/build/cancel", response_model=BuildOut | None)
+def cancel_build(project: ProjectDep, db: DbSession) -> Build | None:
+    build = db.scalars(
+        select(Build)
+        .where(
+            Build.project_id == project.id,
+            Build.status.in_(["pending", "running"]),
+        )
+        .order_by(Build.created_at.desc())
+    ).first()
+    if build is None:
+        return None
+    build.status = "cancelled"
+    db.commit()
+    db.refresh(build)
+    return build

--- a/backend/src/features/reconstruction/inngest_functions.py
+++ b/backend/src/features/reconstruction/inngest_functions.py
@@ -23,6 +23,16 @@ from src.models import Project, Reconstruction
 log = logging.getLogger(__name__)
 
 
+class _Cancelled(Exception):
+    """Raised from the backend progress callback to abort a cancelled run."""
+
+
+def _is_cancelled(reconstruction_id: str) -> bool:
+    with SessionLocal() as db:
+        r = db.get(Reconstruction, reconstruction_id)
+        return r is not None and r.status == "cancelled"
+
+
 @register
 @inngest_client.create_function(
     fn_id="reconstruct-video",
@@ -43,8 +53,10 @@ async def reconstruct_video(ctx: inngest.Context) -> dict:
             recon = db.get(Reconstruction, reconstruction_id)
             if recon is None:
                 raise RuntimeError(f"reconstruction {reconstruction_id} disappeared")
-            recon.status = "running"
-            db.commit()
+            # Don't un-cancel a run the user cancelled before we picked it up.
+            if recon.status != "cancelled":
+                recon.status = "running"
+                db.commit()
             project = db.get(Project, recon.project_id)
             assert project is not None
             video_path = Path(project.video_path) if project.video_path else None
@@ -65,21 +77,34 @@ async def reconstruct_video(ctx: inngest.Context) -> dict:
     extracted = await step.run("extract-frames", _extract)
 
     async def _run_backend() -> dict:
+        # Bail before loading models if already cancelled.
+        if _is_cancelled(reconstruction_id):
+            return {"cancelled": True}
         backend = get_backend(backend_name)
         out_dir = settings.data_dir / "projects" / extracted["project_id"] / "reconstruction"
         t0 = time.time()
         # Forward reconstruction tunables (depth model, FOV override) to the
         # backend; depth_fusion reads them from intrinsics_hint.
         hint = {k: params[k] for k in ("depth_model", "fov_deg") if k in params}
-        result = backend.reconstruct(
-            ReconstructionInput(
-                frames_dir=Path(extracted["frames_dir"]),
-                fps_sampled=float(params.get("fps", 4.0)),
-                intrinsics_hint=hint or None,
-            ),
-            out_dir,
-            progress_cb=lambda _p, _m: None,
-        )
+
+        def _progress(_p: float, _m: str) -> None:
+            # Cooperative cancellation: stop between frames if the user hit
+            # Cancel, so we don't keep burning compute (and memory) on it.
+            if _is_cancelled(reconstruction_id):
+                raise _Cancelled()
+
+        try:
+            result = backend.reconstruct(
+                ReconstructionInput(
+                    frames_dir=Path(extracted["frames_dir"]),
+                    fps_sampled=float(params.get("fps", 4.0)),
+                    intrinsics_hint=hint or None,
+                ),
+                out_dir,
+                progress_cb=_progress,
+            )
+        except _Cancelled:
+            return {"cancelled": True}
         elapsed = time.time() - t0
         return {
             "mesh_path": str(result.mesh_path),
@@ -94,6 +119,9 @@ async def reconstruct_video(ctx: inngest.Context) -> dict:
             r = db.get(Reconstruction, reconstruction_id)
             if r is None:
                 raise RuntimeError(f"reconstruction {reconstruction_id} disappeared")
+            # Leave a cancelled run cancelled — don't flip it to ok.
+            if backend_out.get("cancelled") or r.status == "cancelled":
+                return {"reconstruction_id": reconstruction_id, "cancelled": True}
             r.mesh_path = backend_out["mesh_path"]
             r.status = "ok"
             r.elapsed_s = backend_out["elapsed_s"]

--- a/backend/src/features/reconstruction/router.py
+++ b/backend/src/features/reconstruction/router.py
@@ -186,6 +186,26 @@ def latest_reconstruction(project: ProjectDep, db: DbSession) -> Reconstruction 
     ).first()
 
 
+@router.post("/projects/{project_id}/reconstruction/cancel", response_model=ReconstructionOut | None)
+def cancel_reconstruction(project: ProjectDep, db: DbSession) -> Reconstruction | None:
+    """Mark the in-flight reconstruction cancelled. The running job checks this
+    between frames and stops; a finished job's result is discarded."""
+    recon = db.scalars(
+        select(Reconstruction)
+        .where(
+            Reconstruction.project_id == project.id,
+            Reconstruction.status.in_(["pending", "running"]),
+        )
+        .order_by(Reconstruction.created_at.desc())
+    ).first()
+    if recon is None:
+        return None
+    recon.status = "cancelled"
+    db.commit()
+    db.refresh(recon)
+    return recon
+
+
 class MeshTransformRequest(BaseModel):
     # 16 floats, column-major (THREE.Matrix4.elements). Maps the raw mesh coords
     # to the placement the user arranged in the viewer, so we can bake it in.

--- a/backend/src/features/training/router.py
+++ b/backend/src/features/training/router.py
@@ -78,3 +78,19 @@ def get_policy(project: ProjectDep, policy_id: str, db: DbSession) -> Policy:
     if pol is None:
         raise HTTPException(404, f"unknown policy {policy_id}")
     return pol
+
+
+@router.post("/{project_id}/policies/{policy_id}/cancel", response_model=PolicyOut)
+def cancel_policy(project: ProjectDep, policy_id: str, db: DbSession) -> Policy:
+    """Flag a running training job to stop. The training loop checks this flag
+    each logging interval and halts (the partially-trained policy is kept)."""
+    pol = db.get(Policy, policy_id)
+    if pol is None:
+        raise HTTPException(404, f"unknown policy {policy_id}")
+    m = dict(pol.metrics or {})
+    if not m.get("done") and not m.get("error"):
+        m["cancelled"] = True
+        pol.metrics = m  # reassign so SQLAlchemy tracks the JSONB change
+        db.commit()
+        db.refresh(pol)
+    return pol

--- a/backend/src/features/training/service.py
+++ b/backend/src/features/training/service.py
@@ -47,6 +47,8 @@ class ProgressCB(BaseCallback):
             p = db.get(Policy, self.policy_id)
             if p is None:
                 return False
+            if (p.metrics or {}).get("cancelled"):
+                return False  # user hit Cancel — stop training here
             p.metrics = {
                 **(p.metrics or {}),
                 "progress": min(1.0, self.num_timesteps / max(self.total, 1)),
@@ -98,13 +100,18 @@ def run_training(policy_id: str, mjcf_path: str, total_steps: int, n_envs: int, 
         with SessionLocal() as db:
             p = db.get(Policy, policy_id)
             assert p is not None
-            p.ckpt_path = str(ckpt_path)
-            p.metrics = {
-                **(p.metrics or {}),
-                "progress": 1.0,
-                "elapsed_s": round(elapsed, 2),
-                "done": True,
-            }
+            p.ckpt_path = str(ckpt_path)  # keep the partial checkpoint either way
+            m = p.metrics or {}
+            if m.get("cancelled"):
+                # Stopped early by the user — mark cancelled, not done.
+                p.metrics = {**m, "elapsed_s": round(elapsed, 2), "cancelled": True}
+            else:
+                p.metrics = {
+                    **m,
+                    "progress": 1.0,
+                    "elapsed_s": round(elapsed, 2),
+                    "done": True,
+                }
             db.commit()
     except Exception as exc:
         traceback.print_exc()

--- a/backend/src/features/validation/inngest_functions.py
+++ b/backend/src/features/validation/inngest_functions.py
@@ -32,6 +32,8 @@ async def validate_mesh(ctx: inngest.Context) -> dict:
             v = db.get(Validation, validation_id)
             if v is None:
                 raise RuntimeError(f"validation {validation_id} disappeared")
+            if v.status == "cancelled":
+                return {"validation_id": validation_id, "cancelled": True}
             v.status = "running"
             db.commit()
             recon = db.get(Reconstruction, v.reconstruction_id)
@@ -44,6 +46,8 @@ async def validate_mesh(ctx: inngest.Context) -> dict:
         with SessionLocal() as db:
             v = db.get(Validation, validation_id)
             assert v is not None
+            if v.status == "cancelled":  # cancelled mid-run — discard result
+                return {"validation_id": validation_id, "cancelled": True}
             v.report = report
             v.status = "ok"
             db.commit()

--- a/backend/src/features/validation/router.py
+++ b/backend/src/features/validation/router.py
@@ -62,3 +62,28 @@ def latest_validation(project: ProjectDep, db: DbSession) -> Validation | None:
         .where(Validation.reconstruction_id == recon.id)
         .order_by(Validation.created_at.desc())
     ).first()
+
+
+@router.post("/{project_id}/validate/cancel", response_model=ValidationOut | None)
+def cancel_validation(project: ProjectDep, db: DbSession) -> Validation | None:
+    recon = db.scalars(
+        select(Reconstruction)
+        .where(Reconstruction.project_id == project.id)
+        .order_by(Reconstruction.created_at.desc())
+    ).first()
+    if not recon:
+        return None
+    v = db.scalars(
+        select(Validation)
+        .where(
+            Validation.reconstruction_id == recon.id,
+            Validation.status.in_(["pending", "running"]),
+        )
+        .order_by(Validation.created_at.desc())
+    ).first()
+    if v is None:
+        return None
+    v.status = "cancelled"
+    db.commit()
+    db.refresh(v)
+    return v

--- a/backend/src/inngest_failures.py
+++ b/backend/src/inngest_failures.py
@@ -63,6 +63,9 @@ async def mark_row_failed(ctx: inngest.Context) -> dict:
         row = db.get(Model, row_id)
         if row is None:
             return {"skipped": True, "reason": "row disappeared"}
+        if getattr(row, "status", None) == "cancelled":
+            # User cancelled — don't relabel it as a failure.
+            return {"skipped": True, "reason": "row cancelled"}
         row.status = "failed"
         row.error = (msg or "unknown error")[:1000]
         db.commit()

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -165,7 +165,7 @@ export type BuildRow = {
   n_hulls: number | null;
   bounds: { min: number[]; max: number[] } | null;
   spawn_region: { xmin: number; xmax: number; ymin: number; ymax: number } | null;
-  status: "pending" | "running" | "ok" | "failed";
+  status: "pending" | "running" | "ok" | "failed" | "cancelled";
   error: string | null;
   created_at: string;
 };
@@ -184,6 +184,17 @@ export const useBuild = (projectId: string) => {
       qc.setQueryData(["latest-build", projectId], created);
       qc.invalidateQueries({ queryKey: ["latest-build", projectId] });
       qc.invalidateQueries({ queryKey: ["project-state", projectId] });
+    },
+  });
+};
+
+export const useCancelBuild = (projectId: string) => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => send<BuildRow | null>(`/api/projects/${projectId}/build/cancel`, "POST"),
+    onSuccess: (row) => {
+      if (row) qc.setQueryData(["latest-build", projectId], row);
+      qc.invalidateQueries({ queryKey: ["latest-build", projectId] });
     },
   });
 };
@@ -231,7 +242,7 @@ export type Reconstruction = {
   backend: string;
   params: Record<string, unknown>;
   mesh_path: string | null;
-  status: "pending" | "running" | "ok" | "failed";
+  status: "pending" | "running" | "ok" | "failed" | "cancelled";
   error: string | null;
   elapsed_s: number | null;
   inngest_run_id: string | null;
@@ -271,6 +282,18 @@ export const useReconstruct = (projectId: string) => {
       qc.setQueryData(["reconstruction", projectId], created);
       qc.invalidateQueries({ queryKey: ["reconstruction", projectId] });
       qc.invalidateQueries({ queryKey: ["project-state", projectId] });
+    },
+  });
+};
+
+export const useCancelReconstruction = (projectId: string) => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      send<Reconstruction | null>(`/api/projects/${projectId}/reconstruction/cancel`, "POST"),
+    onSuccess: (row) => {
+      if (row) qc.setQueryData(["reconstruction", projectId], row);
+      qc.invalidateQueries({ queryKey: ["reconstruction", projectId] });
     },
   });
 };
@@ -323,7 +346,7 @@ export type Validation = {
   reconstruction_id: string;
   report: import("@/components/ValidationReport").Report | null;
   user_override: boolean;
-  status: "pending" | "running" | "ok" | "failed";
+  status: "pending" | "running" | "ok" | "failed" | "cancelled";
   error: string | null;
   created_at: string;
 };
@@ -368,6 +391,18 @@ export const useValidate = (projectId: string) => {
   });
 };
 
+export const useCancelValidation = (projectId: string) => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      send<Validation | null>(`/api/projects/${projectId}/validate/cancel`, "POST"),
+    onSuccess: (row) => {
+      if (row) qc.setQueryData(["validation", projectId], row);
+      qc.invalidateQueries({ queryKey: ["validation", projectId] });
+    },
+  });
+};
+
 // ── PR-C: training + trajectories ──────────────────────────────────────────
 
 export type Policy = {
@@ -384,6 +419,7 @@ export type Policy = {
     elapsed_s?: number;
     trace?: Array<{ step: number; reward: number }>;
     done?: boolean;
+    cancelled?: boolean;
     error?: string;
   };
   created_at: string;
@@ -408,7 +444,7 @@ export const usePolicyLive = (projectId: string, policyId: string | null | undef
     enabled: !!policyId,
     refetchInterval: (q) => {
       const m = (q.state.data as Policy | undefined)?.metrics;
-      return m && !m.done ? 1000 : false;
+      return m && !m.done && !m.cancelled ? 1000 : false;
     },
   });
 
@@ -420,6 +456,19 @@ export const useTrain = (projectId: string) => {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["policies", projectId] });
       qc.invalidateQueries({ queryKey: ["project-state", projectId] });
+    },
+  });
+};
+
+export const useCancelTraining = (projectId: string) => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (policyId: string) =>
+      send<Policy>(`/api/projects/${projectId}/policies/${policyId}/cancel`, "POST"),
+    onSuccess: (row) => {
+      qc.setQueryData(["policy", row.id], row);
+      qc.invalidateQueries({ queryKey: ["policy", row.id] });
+      qc.invalidateQueries({ queryKey: ["policies", projectId] });
     },
   });
 };
@@ -443,7 +492,7 @@ export type RunRowDetail = {
   id: string;
   policy_id: string | null;
   baseline: string | null;
-  status: "pending" | "running" | "ok" | "failed";
+  status: "pending" | "running" | "ok" | "failed" | "cancelled";
   error: string | null;
   episodes: number | null;
   successes: number | null;

--- a/frontend/src/routes/p.$projectId.build.tsx
+++ b/frontend/src/routes/p.$projectId.build.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 
 import { ProjectSceneLayout } from "@/components/ProjectSceneLayout";
 import { StatusDot } from "@/components/StatusDot";
-import { useBuild, useLatestBuild } from "@/lib/api";
+import { useBuild, useCancelBuild, useLatestBuild } from "@/lib/api";
 
 export const Route = createFileRoute("/p/$projectId/build")({
   component: BuildScreen,
@@ -12,6 +12,7 @@ export const Route = createFileRoute("/p/$projectId/build")({
 function BuildScreen() {
   const { projectId } = Route.useParams();
   const build = useBuild(projectId);
+  const cancel = useCancelBuild(projectId);
   const { data: latest } = useLatestBuild(projectId);
   const navigate = useNavigate();
   const [enclose, setEnclose] = useState(true);
@@ -45,13 +46,24 @@ function BuildScreen() {
         </span>
       </label>
 
-      <button
-        disabled={build.isPending || running}
-        onClick={() => build.mutate({ enclose })}
-        className="mt-4 px-4 py-2 rounded-sm border-2 border-primary text-primary text-sm font-medium hover:bg-primary/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-      >
-        {running ? "Building…" : build.isPending ? "Queuing…" : latest ? "Re-build env" : "Build env"}
-      </button>
+      <div className="mt-4 flex items-center gap-3">
+        <button
+          disabled={build.isPending || running}
+          onClick={() => build.mutate({ enclose })}
+          className="px-4 py-2 rounded-sm border-2 border-primary text-primary text-sm font-medium hover:bg-primary/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        >
+          {running ? "Building…" : build.isPending ? "Queuing…" : latest ? "Re-build env" : "Build env"}
+        </button>
+        {running && (
+          <button
+            onClick={() => cancel.mutate()}
+            disabled={cancel.isPending}
+            className="px-3 py-2 rounded-sm border border-[var(--status-fail)] text-[var(--status-fail)] text-sm hover:bg-[var(--status-fail)]/10 disabled:opacity-40 transition-colors"
+          >
+            {cancel.isPending ? "Cancelling…" : "Cancel"}
+          </button>
+        )}
+      </div>
 
       {build.error && (
         <p className="mt-3 text-sm text-[var(--status-fail)] mono">

--- a/frontend/src/routes/p.$projectId.reconstruct.tsx
+++ b/frontend/src/routes/p.$projectId.reconstruct.tsx
@@ -7,6 +7,7 @@ import { StatusDot } from "@/components/StatusDot";
 import { RadioCardGroup } from "@/components/ui/RadioCardGroup";
 import {
   useBackends,
+  useCancelReconstruction,
   useLatestReconstruction,
   useProjectState,
   useReconstruct,
@@ -23,6 +24,7 @@ function Reconstruct() {
   const { data: backends = [] } = useBackends();
   const { data: latest } = useLatestReconstruction(projectId);
   const reconstruct = useReconstruct(projectId);
+  const cancel = useCancelReconstruction(projectId);
   const [picked, setPicked] = useState<string>("depth_fusion");
   const [depthModel, setDepthModel] = useState<string>("pro");
   const [fov, setFov] = useState<string>("");
@@ -147,25 +149,36 @@ function Reconstruct() {
         </div>
       )}
 
-      <button
-        disabled={running || reconstruct.isPending}
-        onClick={() => {
-          const f = parseFloat(fov);
-          const params: Record<string, unknown> =
-            picked === "depth_fusion" ? { depth_model: depthModel } : {};
-          if (Number.isFinite(f)) params.fov_deg = f;
-          reconstruct.mutate({ backend: picked, params });
-        }}
-        className="mt-6 px-4 py-2 rounded-sm border-2 border-primary text-primary text-sm font-medium hover:bg-primary/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-      >
-        {running
-          ? "Reconstruction running…"
-          : reconstruct.isPending
-          ? "Queuing…"
-          : latest
-          ? "Re-run reconstruction"
-          : "Run reconstruction"}
-      </button>
+      <div className="mt-6 flex items-center gap-3">
+        <button
+          disabled={running || reconstruct.isPending}
+          onClick={() => {
+            const f = parseFloat(fov);
+            const params: Record<string, unknown> =
+              picked === "depth_fusion" ? { depth_model: depthModel } : {};
+            if (Number.isFinite(f)) params.fov_deg = f;
+            reconstruct.mutate({ backend: picked, params });
+          }}
+          className="px-4 py-2 rounded-sm border-2 border-primary text-primary text-sm font-medium hover:bg-primary/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        >
+          {running
+            ? "Reconstruction running…"
+            : reconstruct.isPending
+            ? "Queuing…"
+            : latest
+            ? "Re-run reconstruction"
+            : "Run reconstruction"}
+        </button>
+        {running && (
+          <button
+            onClick={() => cancel.mutate()}
+            disabled={cancel.isPending}
+            className="px-3 py-2 rounded-sm border border-[var(--status-fail)] text-[var(--status-fail)] text-sm hover:bg-[var(--status-fail)]/10 disabled:opacity-40 transition-colors"
+          >
+            {cancel.isPending ? "Cancelling…" : "Cancel"}
+          </button>
+        )}
+      </div>
 
       {reconstruct.error && (
         <p className="mt-3 text-sm text-[var(--status-fail)] mono">

--- a/frontend/src/routes/p.$projectId.train.tsx
+++ b/frontend/src/routes/p.$projectId.train.tsx
@@ -5,7 +5,13 @@ import { useState } from "react";
 import { MetricsChart } from "@/components/MetricsChart";
 import { StatusDot } from "@/components/StatusDot";
 import { StepNav } from "@/components/StepNav";
-import { usePolicies, usePolicyLive, useProjectState, useTrain } from "@/lib/api";
+import {
+  useCancelTraining,
+  usePolicies,
+  usePolicyLive,
+  useProjectState,
+  useTrain,
+} from "@/lib/api";
 
 export const Route = createFileRoute("/p/$projectId/train")({
   component: Train,
@@ -17,6 +23,7 @@ function Train() {
   const { data: state } = useProjectState(projectId);
   const { data: policies = [] } = usePolicies(projectId);
   const train = useTrain(projectId);
+  const cancelTrain = useCancelTraining(projectId);
   const [activePolicyId, setActivePolicyId] = useState<string | null>(null);
   const liveId = activePolicyId ?? policies[0]?.id ?? null;
   const { data: live } = usePolicyLive(projectId, liveId);
@@ -54,7 +61,8 @@ function Train() {
   }
 
   const progress = live?.metrics?.progress ?? 0;
-  const running = live && !live.metrics?.done && !live.metrics?.error;
+  const running =
+    live && !live.metrics?.done && !live.metrics?.error && !live.metrics?.cancelled;
   const trace = live?.metrics?.trace ?? [];
 
   return (
@@ -105,16 +113,27 @@ function Train() {
           </label>
         </section>
 
-        <button
-          disabled={train.isPending || !!running}
-          onClick={async () => {
-            const p = await train.mutateAsync({ total_steps: steps, n_envs: nEnvs, seed });
-            setActivePolicyId(p.id);
-          }}
-          className="px-4 py-2 rounded-sm border-2 border-primary text-primary text-sm font-medium hover:bg-primary/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-        >
-          {running ? "Training…" : "Train PPO"}
-        </button>
+        <div className="flex items-center gap-3">
+          <button
+            disabled={train.isPending || !!running}
+            onClick={async () => {
+              const p = await train.mutateAsync({ total_steps: steps, n_envs: nEnvs, seed });
+              setActivePolicyId(p.id);
+            }}
+            className="px-4 py-2 rounded-sm border-2 border-primary text-primary text-sm font-medium hover:bg-primary/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            {running ? "Training…" : "Train PPO"}
+          </button>
+          {running && liveId && (
+            <button
+              onClick={() => cancelTrain.mutate(liveId)}
+              disabled={cancelTrain.isPending}
+              className="px-3 py-2 rounded-sm border border-[var(--status-fail)] text-[var(--status-fail)] text-sm hover:bg-[var(--status-fail)]/10 disabled:opacity-40 transition-colors"
+            >
+              {cancelTrain.isPending ? "Cancelling…" : "Cancel"}
+            </button>
+          )}
+        </div>
 
         {train.error && (
           <p className="mt-3 text-sm text-[var(--status-fail)] mono">
@@ -131,11 +150,19 @@ function Train() {
               <div className="flex items-center gap-4">
                 <StatusDot
                   status={
-                    live.metrics?.error ? "fail" : live.metrics?.done ? "ok" : "warn"
+                    live.metrics?.error
+                      ? "fail"
+                      : live.metrics?.cancelled
+                      ? "idle"
+                      : live.metrics?.done
+                      ? "ok"
+                      : "warn"
                   }
                   label={
                     live.metrics?.error
                       ? "error"
+                      : live.metrics?.cancelled
+                      ? `cancelled · ${(progress * 100).toFixed(0)}%`
                       : live.metrics?.done
                       ? `done · ${live.metrics?.elapsed_s?.toFixed(1)}s`
                       : `${(progress * 100).toFixed(0)}% · ${live.metrics?.fps ?? 0} fps`

--- a/frontend/src/routes/p.$projectId.validate.tsx
+++ b/frontend/src/routes/p.$projectId.validate.tsx
@@ -6,6 +6,7 @@ import { ProjectSceneLayout } from "@/components/ProjectSceneLayout";
 import { StatusDot } from "@/components/StatusDot";
 import { ValidationReport, type Report } from "@/components/ValidationReport";
 import {
+  useCancelValidation,
   useLatestReconstruction,
   useLatestValidation,
   useProjectState,
@@ -23,6 +24,7 @@ function Validate() {
   const { data: recon } = useLatestReconstruction(projectId);
   const { data: latest } = useLatestValidation(projectId);
   const validate = useValidate(projectId);
+  const cancel = useCancelValidation(projectId);
   const [override, setOverride] = useState(false);
 
   const reconReady = recon?.status === "ok";
@@ -69,19 +71,30 @@ function Validate() {
         </p>
       </header>
 
-      <button
-        disabled={validate.isPending || running}
-        onClick={() => validate.mutate()}
-        className="mt-6 px-4 py-2 rounded-sm border-2 border-primary text-primary text-sm font-medium hover:bg-primary/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-      >
-        {running
-          ? "Validating…"
-          : validate.isPending
-          ? "Queuing…"
-          : latest
-          ? "Re-validate"
-          : "Run validation"}
-      </button>
+      <div className="mt-6 flex items-center gap-3">
+        <button
+          disabled={validate.isPending || running}
+          onClick={() => validate.mutate()}
+          className="px-4 py-2 rounded-sm border-2 border-primary text-primary text-sm font-medium hover:bg-primary/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        >
+          {running
+            ? "Validating…"
+            : validate.isPending
+            ? "Queuing…"
+            : latest
+            ? "Re-validate"
+            : "Run validation"}
+        </button>
+        {running && (
+          <button
+            onClick={() => cancel.mutate()}
+            disabled={cancel.isPending}
+            className="px-3 py-2 rounded-sm border border-[var(--status-fail)] text-[var(--status-fail)] text-sm hover:bg-[var(--status-fail)]/10 disabled:opacity-40 transition-colors"
+          >
+            {cancel.isPending ? "Cancelling…" : "Cancel"}
+          </button>
+        )}
+      </div>
 
       {validate.error && (
         <p className="mt-3 text-sm text-[var(--status-fail)] mono">


### PR DESCRIPTION
Add a **Cancel** control to each long-running step — Reconstruct, Validate, Build, Train — shown beside the run button while a job is in flight.

## Behaviour
- **Cancel endpoints** mark the in-flight row `status = "cancelled"` (Train uses a `metrics.cancelled` flag, since Policy has no status column).
- **Heavy steps actually stop the compute** (this matters on a memory-constrained machine):
  - *Reconstruct*: the depth-fusion progress callback checks the row between frames and aborts.
  - *Train*: the PPO callback returns `False` to halt training; the partial checkpoint is kept.
- **Fast steps** (Validate, Build) finish their single step but their result is discarded.
- **Guards** so a cancel sticks: each inngest function skips its persist step if the row is cancelled (won't flip it to `ok`), and the shared failure handler won't relabel a cancelled row as `failed`.

## Frontend
- `useCancelReconstruction / useCancelValidation / useCancelBuild / useCancelTraining` hooks.
- A Cancel button next to each step's run button while running; polling stops once the row leaves pending/running.
- `"cancelled"` added to the status unions + StatusDot wiring (Train shows `cancelled · NN%`).

## Verification
- Backend compiles; frontend `tsc --noEmit` clean.
- (Live click-through pending a stable Docker/Postgres on the dev box.)