### PR TITLE
Fix Validate + Build OOM/hang on large reconstruction meshes

### DIFF
--- a/backend/src/features/validation/checks.py
+++ b/backend/src/features/validation/checks.py
@@ -24,35 +24,99 @@ class CheckResult:
     fix: str
 
 
+# ---------------------------------------------------------- component analysis
+#
+# A back-projected reconstruction is often millions of faces split into
+# thousands of tiny disconnected "noise islands". `mesh.split()` materialises a
+# full Trimesh *per component*, which exhausts memory and hangs/kills the
+# process. Instead we label components cheaply with face-adjacency (scipy) and
+# only materialise the largest few to run the per-component watertight / hull
+# tests. The three split-based checks read this precomputed summary.
+
+_MAX_SUBMESHES = 48  # cap how many of the largest components we copy out
+
+
+@dataclass
+class _Components:
+    count: int            # total number of connected components
+    face_sizes: list[int]  # face count per component (all of them — cheap)
+    sampled: int          # how many of the largest were materialised
+    closed: int           # of those sampled, how many are watertight
+    hull_vol: float       # summed convex-hull volume of the sampled components
+    mesh_vol: float       # |mesh.volume|
+
+
+def _analyze_components(mesh: trimesh.Trimesh) -> _Components:
+    """Connected-component stats WITHOUT mesh.split() (which copies a full
+    Trimesh per component → OOM on a multi-million-face reconstruction).
+    Best-effort: never raises."""
+    nf = len(mesh.faces)
+    if nf == 0:
+        return _Components(0, [], 0, 0, 0.0, 0.0)
+    try:
+        from trimesh.graph import connected_components
+
+        comps = connected_components(
+            mesh.face_adjacency, min_len=1, nodes=np.arange(nf)
+        )
+    except Exception:
+        # Fall back to treating the whole mesh as a single component.
+        comps = [np.arange(nf)]
+
+    face_sizes = [int(len(c)) for c in comps]
+    order = np.argsort(face_sizes)[::-1][:_MAX_SUBMESHES]  # largest first
+    closed = 0
+    hull_vol = 0.0
+    for i in order:
+        try:
+            sub = mesh.submesh([comps[i]], append=True, repair=False)
+            if sub.is_watertight:
+                closed += 1
+            hull_vol += abs(float(sub.convex_hull.volume))
+        except Exception:
+            pass
+    try:
+        mesh_vol = abs(float(mesh.volume))
+    except Exception:
+        mesh_vol = 0.0
+    return _Components(len(comps), face_sizes, int(len(order)), closed, hull_vol, mesh_vol)
+
+
+def _components(mesh: trimesh.Trimesh) -> _Components:
+    cached = mesh.metadata.get("_wv_comps") if hasattr(mesh, "metadata") else None
+    return cached if isinstance(cached, _Components) else _analyze_components(mesh)
+
+
 # ---------------------------------------------------------- watertight
 
 def check_watertight(mesh: trimesh.Trimesh) -> CheckResult:
     """Watertightness for a multi-part scene is measured per component. A
     scene of N closed boxes is "watertight enough" even though the union
     isn't a single closed surface."""
-    parts = mesh.split(only_watertight=False)
-    if not parts:
+    comps = _components(mesh)
+    if comps.count == 0:
         return CheckResult("watertight", "fail", "empty mesh", "no faces to analyze")
-    closed = sum(1 for p in parts if p.is_watertight)
-    ratio = closed / len(parts)
+    denom = max(comps.sampled, 1)  # measured over the largest components
+    closed = comps.closed
+    ratio = closed / denom
     if ratio >= 0.95:
         return CheckResult(
             "watertight",
             "pass",
-            f"{closed}/{len(parts)} components are closed",
+            f"{closed}/{denom} largest components are closed",
             "",
         )
     if ratio >= 0.5:
         return CheckResult(
             "watertight",
             "warn",
-            f"only {closed}/{len(parts)} components closed",
+            f"only {closed}/{denom} largest components closed",
             "Half-open meshes still work for navigation but the agent can wander past open faces.",
         )
     return CheckResult(
         "watertight",
         "warn",
-        f"{closed}/{len(parts)} components closed — open/partial scan",
+        f"{closed}/{denom} largest components closed — open/partial scan",
         "Partial captures (e.g. half a room) are open at the back. Build wraps "
         "the scene in invisible boundary walls so the agent stays inside; "
         "multi-frame video or LiDAR gives a more complete mesh.",
@@ -66,12 +130,12 @@ def check_connected_components(mesh: trimesh.Trimesh) -> CheckResult:
     its own watertight box). The signal we want: is there ONE dominant
     component, or is the mesh shattered into uniform small pieces?
     """
-    parts = mesh.split(only_watertight=False)
-    n = len(parts)
+    comps = _components(mesh)
+    n = comps.count
     if n <= 1:
         return CheckResult("connected_components", "pass", "single connected mesh", "")
 
-    sizes = sorted((len(p.faces) for p in parts), reverse=True)
+    sizes = sorted(comps.face_sizes, reverse=True)
     largest_share = sizes[0] / max(sum(sizes), 1)
 
     if largest_share >= 0.5 or n <= 20:
@@ -181,22 +245,16 @@ def check_convex_decomp_quality(mesh: trimesh.Trimesh) -> CheckResult:
     """Decompose into convex components (per-connected-component hulls) and
     check volume preservation. VHACD would be more accurate; we use the
     simpler fallback that rl_env.build also uses by default."""
-    parts = mesh.split(only_watertight=False)
-    n_hulls = len(parts)
+    comps = _components(mesh)
+    n_hulls = comps.count
     if n_hulls == 0:
         return CheckResult("convex_decomp_quality", "fail", "no hulls produced", "empty mesh")
 
-    try:
-        original_vol = abs(float(mesh.volume))
-    except Exception:
-        original_vol = 0.0
-    hull_vol = 0.0
-    for p in parts:
-        try:
-            hull_vol += abs(float(p.convex_hull.volume))
-        except Exception:
-            pass
-
+    # hull_vol is summed over the largest sampled components; for open
+    # reconstructions mesh.volume is ~0 so vol_ratio defaults to 1.0 and the
+    # hull-count thresholds drive the verdict.
+    original_vol = comps.mesh_vol
+    hull_vol = comps.hull_vol
     vol_ratio = hull_vol / max(original_vol, 1e-6) if original_vol > 1e-3 else 1.0
 
     if 3 <= n_hulls <= 64 and vol_ratio >= 0.7:
@@ -278,6 +336,12 @@ def run_all(mesh_path: str | Path) -> dict:
             "overall": "fail",
             "error": f"could not load mesh as trimesh.Trimesh (got {type(mesh).__name__})",
         }
+    # Analyse connected components ONCE (memory-bounded) and cache it so the
+    # split-based checks don't each re-walk a multi-million-face mesh.
+    try:
+        mesh.metadata["_wv_comps"] = _analyze_components(mesh)
+    except Exception:
+        pass
     results = [check(mesh) for check in CATALOG.values()]
     statuses = {r.status for r in results}
     overall = "fail" if "fail" in statuses else ("warn" if "warn" in statuses else "pass")

--- a/rl_env/rl_env/build.py
+++ b/rl_env/rl_env/build.py
@@ -116,23 +116,73 @@ def preprocess(mesh: trimesh.Trimesh, cfg: BuildConfig) -> tuple[trimesh.Trimesh
 # ---------------------------------------------------------------------------
 
 
+# A reconstruction mesh can be millions of faces; coarse collision geometry
+# doesn't need that, and the heavy ops below choke on it. Decimate first.
+_COLLISION_MAX_FACES = 120_000
+
+
+def _decimate_for_collision(mesh: trimesh.Trimesh, max_faces: int = _COLLISION_MAX_FACES) -> trimesh.Trimesh:
+    """Best-effort reduce face count before decomposition. If no decimation
+    backend is available, return the mesh unchanged — the component fallback
+    below is memory-safe either way."""
+    if len(mesh.faces) <= max_faces:
+        return mesh
+    try:
+        out = mesh.simplify_quadric_decimation(face_count=max_faces)
+        if out is not None and len(out.faces) > 0:
+            return out
+    except Exception:
+        pass
+    return mesh
+
+
+def _largest_components(mesh: trimesh.Trimesh, k: int) -> list[trimesh.Trimesh]:
+    """Up to `k` largest connected components, materialised one at a time.
+
+    Avoids `mesh.split()` — which builds a full Trimesh for *every* component,
+    OOMing on a back-projected mesh with thousands of tiny noise islands. We
+    label components cheaply (face adjacency) and only copy out the biggest few.
+    """
+    nf = len(mesh.faces)
+    if nf == 0:
+        return [mesh]
+    try:
+        from trimesh.graph import connected_components
+
+        comps = connected_components(mesh.face_adjacency, min_len=1, nodes=np.arange(nf))
+    except Exception:
+        return [mesh]
+    comps = sorted(comps, key=len, reverse=True)[: max(k, 1)]
+    out: list[trimesh.Trimesh] = []
+    for fi in comps:
+        try:
+            out.append(mesh.submesh([fi], append=True, repair=False))
+        except Exception:
+            pass
+    return out or [mesh]
+
+
 def decompose(mesh: trimesh.Trimesh, cfg: BuildConfig) -> list[trimesh.Trimesh]:
     """Return a list of convex hull meshes covering `mesh`.
 
     Strategy:
-      1. If trimesh has a working VHACD/CoACD backend, use it.
-      2. Else split into connected components and take convex hull of each.
-      3. If that yields too few hulls (e.g. one big merged mesh), fall back to
-         a single convex hull of the entire scene — coarse but always works.
+      1. Decimate huge meshes (coarse collision geometry needs few faces).
+      2. If trimesh has a working VHACD/CoACD backend, use it.
+      3. Else take convex hulls of the largest connected components.
+      4. If that yields nothing, a single convex hull of the whole scene.
 
     The MVP intentionally accepts coarse collision geometry; tightening this
     is a known follow-up (PRD: "balance collision fidelity against simulation
     speed", Key technical challenge #1).
     """
-    if cfg.decompose:
+    work = _decimate_for_collision(mesh)
+
+    # Only attempt VHACD if the mesh is a sane size — it's slow/heavy on a
+    # multi-million-face mesh, and the component fallback is always safe.
+    if cfg.decompose and len(work.faces) <= _COLLISION_MAX_FACES * 4:
         try:
             hulls = trimesh.decomposition.convex_decomposition(
-                mesh, maxNumVerticesPerCH=64, resolution=100_000
+                work, maxNumVerticesPerCH=64, resolution=100_000
             )
             if hulls:
                 hulls = [h for h in hulls if h.is_volume and h.volume > 1e-6]
@@ -141,12 +191,8 @@ def decompose(mesh: trimesh.Trimesh, cfg: BuildConfig) -> list[trimesh.Trimesh]:
         except Exception:
             pass
 
-    components = mesh.split(only_watertight=False)
-    if len(components) == 0:
-        components = [mesh]
-
     hulls: list[trimesh.Trimesh] = []
-    for c in components[: cfg.max_hulls]:
+    for c in _largest_components(work, cfg.max_hulls):
         try:
             h = c.convex_hull
             if h.is_volume and h.volume > 1e-6:
@@ -155,7 +201,10 @@ def decompose(mesh: trimesh.Trimesh, cfg: BuildConfig) -> list[trimesh.Trimesh]:
             continue
 
     if not hulls:
-        hulls = [mesh.convex_hull]
+        try:
+            hulls = [work.convex_hull]
+        except Exception:
+            hulls = [mesh.convex_hull]
 
     return hulls
 


### PR DESCRIPTION
## Problem
Real reconstructions are ~3.5M faces. Both **Validate** and **Build** walked the mesh with `mesh.split(only_watertight=False)`, which materialises a full `Trimesh` per connected component — and a back-projected mesh has *thousands* of tiny noise islands. That exhausted memory: Validate hung at `running` (and could crash the machine); Build would hit the same path when no VHACD backend is installed.

## Fix (same approach in both)
Label connected components cheaply via face-adjacency (`trimesh.graph.connected_components`, scipy) — no per-component copies — and only materialise the largest few.

- **Validate** (`checks.py`): compute component stats once, cache on `mesh.metadata`; the watertight / connected_components / convex_decomp checks read it. Materialise ≤48 largest components for the watertight/hull tests.
- **Build** (`rl_env/build.py`): decimate large meshes first (coarse collision geometry needs few faces), guard VHACD behind a face cap, and take convex hulls of the largest components instead of `split()`.

## Verification
- Validate: rewritten checks verified on a synthetic two-box mesh (all six verdicts correct).
- Build: sample-room build unchanged (13 hulls, MJCF loads in MuJoCo).
- Not run on the real 71MB mesh (per request) — but the exact `mesh.split()` calls that caused the OOM are removed; peak memory is now bounded (one component at a time).