### PR TITLE
RL navigation demo: greedy-vs-PPO race in the scanned room + host-mode backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ shared/ts/api.d.ts
 .env
 .env.local
 .env.*.local
+
+# local host-mode SQLite database
+backend/*.db

--- a/backend/src/db.py
+++ b/backend/src/db.py
@@ -14,7 +14,9 @@ class Base(DeclarativeBase):
 
 
 _settings = get_settings()
-engine = create_engine(_settings.database_url, pool_pre_ping=True, future=True)
+_url = _settings.database_url
+_connect_args = {"check_same_thread": False} if _url.startswith("sqlite") else {}
+engine = create_engine(_url, pool_pre_ping=True, future=True, connect_args=_connect_args)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
 
 

--- a/backend/src/features/builds/router.py
+++ b/backend/src/features/builds/router.py
@@ -1,13 +1,11 @@
 """Build route: queues a Build row + emits Inngest event."""
 from __future__ import annotations
 
-import inngest
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, BackgroundTasks, HTTPException
 from nanoid import generate as nanoid
 from sqlalchemy import select
 
 from src.deps import DbSession, ProjectDep
-from src.inngest_client import inngest_client
 from src.models import Build, Reconstruction
 from src.schemas import BuildOut, BuildRequest
 
@@ -19,6 +17,7 @@ async def build_project(
     project: ProjectDep,
     body: BuildRequest,
     db: DbSession,
+    background_tasks: BackgroundTasks,
 ) -> Build:
     recon: Reconstruction | None = None
     if body.reconstruction_id:
@@ -45,22 +44,81 @@ async def build_project(
     db.commit()
     db.refresh(build)
 
-    await inngest_client.send(
-        events=[
-            inngest.Event(
-                name="build/requested",
-                data={
-                    "build_id": build.id,
-                    "target_diagonal_m": body.target_diagonal_m,
-                    "max_hulls": body.max_hulls,
-                    "up_axis": body.up_axis,
-                    "enclose": body.enclose,
-                },
-            )
-        ]
+    background_tasks.add_task(
+        _run_build_blocking, build.id, body.target_diagonal_m, body.max_hulls,
+        body.up_axis, body.enclose,
     )
 
     return build
+
+
+def _run_build_blocking(
+    build_id: str, target_diagonal_m: float | None, max_hulls: int | None,
+    up_axis: str | None, enclose: bool,
+) -> None:
+    """In-process build worker (host mode, no Inngest). mesh -> MJCF."""
+    import traceback
+
+    from rl_env.build import BuildConfig, build_environment
+
+    from src.config import get_settings
+    from src.db import SessionLocal
+
+    settings = get_settings()
+    try:
+        with SessionLocal() as db:
+            b = db.get(Build, build_id)
+            if b is None:
+                return
+            b.status = "running"
+            db.commit()
+            recon = db.get(Reconstruction, b.reconstruction_id) if b.reconstruction_id else None
+            project_id = b.project_id
+            mesh_path = recon.mesh_path if recon and recon.mesh_path else None
+
+        if not mesh_path:
+            raise RuntimeError("no reconstruction mesh — run Reconstruct first")
+
+        out_dir = settings.data_dir / "projects" / project_id / "build"
+        artifacts = build_environment(
+            BuildConfig(
+                mesh_path=mesh_path,
+                out_dir=str(out_dir),
+                target_diagonal_m=target_diagonal_m or settings.default_target_diagonal_m,
+                up_axis=up_axis or "auto",
+                max_hulls=max_hulls or 64,
+                enclose=enclose,
+            )
+        )
+
+        with SessionLocal() as db:
+            b = db.get(Build, build_id)
+            assert b is not None
+            b.mjcf_path = str(artifacts.mjcf_path)
+            b.n_hulls = artifacts.n_hulls
+            b.bounds = {
+                "min": artifacts.bounds[0].tolist(),
+                "max": artifacts.bounds[1].tolist(),
+                # 4x4 raw-mesh -> sim transform so the viewer can place the
+                # robot's sim-frame trajectory onto the textured mesh.
+                "raw_to_sim": artifacts.raw_to_sim.tolist() if artifacts.raw_to_sim is not None else None,
+            }
+            b.spawn_region = {
+                "xmin": artifacts.spawn_region[0],
+                "xmax": artifacts.spawn_region[1],
+                "ymin": artifacts.spawn_region[2],
+                "ymax": artifacts.spawn_region[3],
+            }
+            b.status = "ok"
+            db.commit()
+    except Exception as exc:
+        with SessionLocal() as db:
+            b = db.get(Build, build_id)
+            if b is not None:
+                b.status = "failed"
+                b.error = f"{exc.__class__.__name__}: {exc}"[:1000]
+                db.commit()
+        traceback.print_exc()
 
 
 @router.get("/{project_id}/build/latest", response_model=BuildOut | None)

--- a/backend/src/features/reconstruction/router.py
+++ b/backend/src/features/reconstruction/router.py
@@ -69,6 +69,7 @@ async def queue_reconstruction(
     project: ProjectDep,
     body: ReconstructionRequest,
     db: DbSession,
+    background_tasks: BackgroundTasks,
 ) -> Reconstruction:
     if not project.video_path:
         raise HTTPException(400, "no video uploaded — POST /upload-video first")
@@ -90,21 +91,12 @@ async def queue_reconstruction(
     db.commit()
     db.refresh(recon)
 
-    # Inngest is the single source of truth now. The durable function in
-    # backend/src/features/reconstruction/inngest_functions.py picks up
-    # the event, runs extract_frames → run_backend → persist, and writes
-    # the row's status from pending → ok/failed.
-    await inngest_client.send(
-        events=[
-            inngest.Event(
-                name="reconstruction/requested",
-                data={
-                    "reconstruction_id": recon.id,
-                    "backend": backend_name,
-                    "params": body.params,
-                },
-            )
-        ]
+    # Local host mode (no Inngest/docker): run the in-process worker as a
+    # FastAPI background task. `_run_reconstruction_blocking` is sync, so
+    # FastAPI runs it in a threadpool; the row's status moves
+    # pending → running → ok/failed while the frontend polls.
+    background_tasks.add_task(
+        _run_reconstruction_blocking, recon.id, backend_name, body.params
     )
 
     return recon

--- a/backend/src/features/replay/router.py
+++ b/backend/src/features/replay/router.py
@@ -7,15 +7,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import inngest
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, BackgroundTasks, HTTPException
 from nanoid import generate as nanoid
 from pydantic import BaseModel
 from sqlalchemy import select
 
 from src.deps import DbSession, ProjectDep
-from src.inngest_client import inngest_client
-from src.models import Build, Policy, Run
+from src.models import Build, Policy, Reconstruction, Run
 from src.schemas import RunOut
 
 router = APIRouter()
@@ -30,7 +28,9 @@ class ReplayRequest(BaseModel):
 
 
 @router.post("/{project_id}/replay", response_model=RunOut)
-async def replay(project: ProjectDep, body: ReplayRequest, db: DbSession) -> Run:
+async def replay(
+    project: ProjectDep, body: ReplayRequest, db: DbSession, background_tasks: BackgroundTasks
+) -> Run:
     build = db.scalars(
         select(Build)
         .where(Build.project_id == project.id, Build.status == "ok")
@@ -58,23 +58,212 @@ async def replay(project: ProjectDep, body: ReplayRequest, db: DbSession) -> Run
     db.commit()
     db.refresh(run)
 
-    await inngest_client.send(
-        events=[
-            inngest.Event(
-                name="replay/requested",
-                data={
-                    "run_id": run.id,
-                    "policy": body.policy,
-                    "policy_id": policy_id,
-                    "project_id": project.id,
-                    "episodes": body.episodes,
-                    "max_steps": body.max_steps,
-                    "seed": body.seed,
-                },
-            )
-        ]
+    background_tasks.add_task(
+        _run_replay_blocking, run.id, body.policy, policy_id, project.id,
+        body.episodes, body.max_steps, body.seed,
     )
     return run
+
+
+def _run_replay_blocking(
+    run_id: str, policy_name: str, policy_id: str | None, project_id: str,
+    episodes: int, max_steps: int, seed: int,
+) -> None:
+    """In-process rollout worker (host mode, no Inngest). Writes trajectories
+    JSON the frontend replays, and updates the Run row."""
+    import traceback
+
+    import numpy as np
+
+    from rl_env.env import NavEnv, TaskConfig
+    from src.config import get_settings
+    from src.db import SessionLocal
+
+    def _greedy(obs, rng):
+        v = obs[4:6]
+        n = float(np.linalg.norm(v))
+        return np.zeros(2, dtype=np.float32) if n < 1e-6 else (v / n).astype(np.float32)
+
+    def _random(obs, rng):
+        return rng.uniform(-1.0, 1.0, size=2).astype(np.float32)
+
+    settings = get_settings()
+    try:
+        with SessionLocal() as db:
+            r = db.get(Run, run_id)
+            if r is None:
+                return
+            r.status = "running"
+            db.commit()
+            policy = db.get(Policy, policy_id) if policy_id else None
+            if policy:
+                build = db.get(Build, policy.build_id)
+            else:
+                build = db.scalars(
+                    select(Build).where(Build.project_id == project_id)
+                    .order_by(Build.created_at.desc())
+                ).first()
+            if build is None or not build.mjcf_path:
+                raise RuntimeError("no built scene for this project")
+            mjcf_path = build.mjcf_path
+            bounds = build.bounds
+            spawn_region = build.spawn_region
+            build_project_id = build.project_id
+            ckpt_path = policy.ckpt_path if policy else None
+            recon = (
+                db.get(Reconstruction, build.reconstruction_id)
+                if build.reconstruction_id
+                else None
+            )
+            try:
+                footprint = _nav_footprint(build, recon.mesh_path if recon else None)
+            except Exception:
+                footprint = None
+
+        if policy_name == "ppo":
+            if not ckpt_path or not Path(ckpt_path).exists():
+                raise RuntimeError("no trained PPO policy")
+            from stable_baselines3 import PPO
+
+            sb3 = PPO.load(ckpt_path, device="cpu")
+
+            def policy_fn(obs, _rng):
+                action, _ = sb3.predict(obs, deterministic=True)
+                return action
+        else:
+            policy_fn = _greedy if policy_name == "greedy" else _random
+
+        # Spawn start & goal apart, but keep them in the CENTRAL part of the
+        # footprint. A partial/curved reconstruction doesn't fill its bounding
+        # box, so the box corners are empty space ("outside the room") — spawn
+        # in the inner ~65% so the robot stays on actual floor.
+        tcfg = {"max_steps": max_steps}
+        try:
+            sr = spawn_region or {}
+            cx = (float(sr["xmin"]) + float(sr["xmax"])) / 2
+            cy = (float(sr["ymin"]) + float(sr["ymax"])) / 2
+            xr = (float(sr["xmax"]) - float(sr["xmin"])) / 2 * 0.65
+            yr = (float(sr["ymax"]) - float(sr["ymin"])) / 2 * 0.65
+            tcfg["spawn_region"] = (cx - xr, cx + xr, cy - yr, cy + yr)
+            tcfg["min_start_goal_dist"] = max(0.8, 0.7 * float(np.hypot(2 * xr, 2 * yr)))
+        except Exception:
+            pass
+        env = NavEnv(mjcf_path, task=TaskConfig(**tcfg))
+        rng = np.random.default_rng(seed)
+        successes = 0
+        rewards = []
+        episodes_out = []
+        for ep in range(episodes):
+            if footprint:
+                # Spawn on the SCANNED floor, not the bounding box — a partial
+                # scan's box corners are empty space "outside the room". Each
+                # episode draws a fresh far-apart pair of footprint cells.
+                cells = np.asarray(footprint["free_cells"], dtype=float)
+                ep_rng = np.random.default_rng(seed + ep)
+                want = 0.55 * float(footprint.get("max_dist", 2.0))
+                pick = cells[ep_rng.integers(len(cells))], cells[ep_rng.integers(len(cells))]
+                for _ in range(64):
+                    a_, b_ = cells[ep_rng.integers(len(cells))], cells[ep_rng.integers(len(cells))]
+                    if float(np.linalg.norm(a_ - b_)) >= want:
+                        pick = a_, b_
+                        break
+                env.task.fixed_spawn = (float(pick[0][0]), float(pick[0][1]))
+                env.task.fixed_goal = (float(pick[1][0]), float(pick[1][1]))
+            obs, _ = env.reset(seed=seed + ep)
+            ep_reward = 0.0
+            ep_steps = 0
+            collisions = 0
+            traj = []
+            info: dict = {}
+            spawn_xy = env._agent_xy().astype(float).tolist()
+            goal_xy = env._goal_xy().astype(float).tolist()
+            # Obstacle-avoidance: the last 16 obs are lidar ranges. When the
+            # nearest ray drops below PROX the robot is hugging an obstacle; if
+            # it leaves that proximity span without ever colliding, it "avoided"
+            # the obstacle. We count those events + where they happened.
+            PROX = 0.55
+            avoided = 0
+            in_prox = False
+            prox_collided = False
+            avoid_points: list[dict] = []
+            for _ in range(max_steps):
+                a = policy_fn(obs, rng)
+                obs, rew, term, trunc, info = env.step(a)
+                ep_reward += rew
+                ep_steps += 1
+                curr = env._agent_xy().astype(float)
+                col = bool(env._has_scene_collision())
+                if col:
+                    collisions += 1
+                lidar = obs[-16:]
+                near = bool(float(np.min(lidar)) < PROX) if len(lidar) else False
+                if near and not in_prox:
+                    in_prox, prox_collided = True, False
+                if in_prox and col:
+                    prox_collided = True
+                if in_prox and not near:
+                    if not prox_collided:
+                        avoided += 1
+                        avoid_points.append({"x": float(curr[0]), "y": float(curr[1])})
+                    in_prox = False
+                traj.append({
+                    "step": ep_steps, "x": float(curr[0]), "y": float(curr[1]),
+                    "collision": col, "near": near,
+                })
+                if term or trunc:
+                    break
+            if in_prox and not prox_collided:
+                avoided += 1
+            success = bool(info.get("success", False))
+            distance = float(info.get("distance", -1.0))
+            if success and traj:
+                # Dock the final success_radius stretch so the rendered robot
+                # visibly arrives AT the goal marker — interpolated at the
+                # normal per-step pace so it rolls in, not teleports.
+                last = np.array([traj[-1]["x"], traj[-1]["y"]], dtype=float)
+                g = np.array(goal_xy, dtype=float)
+                n = max(2, int(float(np.linalg.norm(g - last)) / 0.025))
+                for k in range(1, n + 1):
+                    p = last + (g - last) * (k / n)
+                    traj.append({
+                        "step": ep_steps + k, "x": float(p[0]), "y": float(p[1]),
+                        "collision": False, "near": False,
+                    })
+            if success:
+                successes += 1
+            rewards.append(ep_reward)
+            episodes_out.append({
+                "steps": ep_steps, "reward": round(float(ep_reward), 3),
+                "distance": round(distance, 3), "success": success,
+                "avoided": avoided, "avoid_points": avoid_points, "collisions": collisions,
+                "spawn": spawn_xy, "goal": goal_xy, "trajectory": traj,
+            })
+        env.close()
+        avg_reward = float(np.mean(rewards)) if rewards else 0.0
+
+        traj_dir = settings.data_dir / "projects" / build_project_id / "runs" / run_id
+        traj_dir.mkdir(parents=True, exist_ok=True)
+        traj_path = traj_dir / "trajectories.json"
+        traj_path.write_text(json.dumps(
+            {"bounds": bounds, "spawn_region": spawn_region, "episodes": episodes_out}
+        ))
+
+        with SessionLocal() as db:
+            r = db.get(Run, run_id)
+            assert r is not None
+            r.episodes = episodes
+            r.successes = successes
+            r.avg_reward = round(avg_reward, 3)
+            r.trajectories_path = str(traj_path)
+            r.status = "ok"
+            db.commit()
+    except Exception as exc:
+        with SessionLocal() as db:
+            r = db.get(Run, run_id)
+            if r is not None:
+                r.status = "failed"
+                db.commit()
+        traceback.print_exc()
 
 
 @router.get("/{project_id}/runs/{run_id}", response_model=RunOut)
@@ -94,3 +283,364 @@ def get_run_trajectories(project: ProjectDep, run_id: str, db: DbSession) -> dic
     if not p.exists():
         raise HTTPException(404, "trajectories file missing on disk")
     return json.loads(p.read_text())
+
+
+# --------------------------------------------------------------------------- #
+# Head-to-head: greedy vs PPO on the SAME start→goal (shows where PPO wins)
+# --------------------------------------------------------------------------- #
+class CompareRequest(BaseModel):
+    seed: int | None = None
+    max_steps: int = 300
+
+
+def _build_raw_to_sim(build) -> tuple[list | None, float | None]:
+    """(raw_to_sim, floor_z) from build.bounds, falling back to the build dir's
+    metadata.json for builds made before these were stored in the DB."""
+    b = build.bounds or {}
+    raw_to_sim = b.get("raw_to_sim")
+    floor_z = (b.get("min") or [None, None, None])[2]
+    if raw_to_sim is None or floor_z is None:
+        try:
+            meta = json.loads((Path(build.mjcf_path).parent / "metadata.json").read_text())
+            raw_to_sim = raw_to_sim if raw_to_sim is not None else meta.get("raw_to_sim")
+            floor_z = floor_z if floor_z is not None else meta.get("floor_z")
+        except Exception:
+            pass
+    return raw_to_sim, floor_z
+
+
+def _nav_footprint(build, mesh_path: str | None) -> dict | None:
+    """Occupancy footprint of the *scanned floor* in sim coordinates.
+
+    Partial phone scans don't fill their bounding box — spawning anywhere in the
+    box puts the robot visually "outside the room". This grids the mesh's
+    floor-band vertices, drops cells near obstacles/walls (points in the band
+    above the floor), keeps the largest connected free region, and returns:
+      floor_z      — the REAL floor height (densest vertex slab), not the noisy
+                     mesh minimum, so balls render resting on the visible floor
+      free_cells   — [x, y] centers the robot can stand on
+      corner_pair  — the two farthest-apart free cells (corner → opposite corner)
+    Cached as nav_footprint.json next to the MJCF. Returns None for meshes too
+    small/synthetic to profile (caller falls back to box spawning).
+    """
+    if not mesh_path or not Path(mesh_path).exists() or not build.mjcf_path:
+        return None
+    cache = Path(build.mjcf_path).parent / "nav_footprint.json"
+    if cache.exists():
+        try:
+            return json.loads(cache.read_text())
+        except Exception:
+            pass
+
+    import numpy as np
+    import trimesh
+
+    raw_to_sim, _ = _build_raw_to_sim(build)
+    if raw_to_sim is None:
+        return None
+    mesh = trimesh.load(mesh_path, process=False)
+    v = np.asarray(mesh.vertices)
+    if len(v) < 20_000:  # synthetic fixtures — footprint profiling is meaningless
+        return None
+    M = np.asarray(raw_to_sim, dtype=float)
+    vs = (M[:3, :3] @ v.T).T + M[:3, 3]
+    zs = vs[:, 2]
+
+    # Real floor = densest z-slab in the lower 40% of the height range.
+    hist, edges = np.histogram(zs, bins=80)
+    i = int(np.argmax(hist[: int(80 * 0.4)]))
+    floor_z = float((edges[i] + edges[i + 1]) / 2)
+
+    floor = vs[(zs > floor_z - 0.12) & (zs < floor_z + 0.12)][:, :2]
+    obst = vs[(zs > floor_z + 0.18) & (zs < floor_z + 1.4)][:, :2]
+    if len(floor) < 5_000:
+        return None
+
+    CELL = 0.15
+    origin = vs[:, :2].min(axis=0)
+    from collections import Counter
+
+    def cells_of(pts):
+        return Counter(map(tuple, np.floor((pts - origin) / CELL).astype(int)))
+
+    gf, go = cells_of(floor), cells_of(obst)
+    thr = max(3, int(np.percentile(np.array(list(gf.values())), 30) * 0.5))
+    floor_cells = {c for c, n in gf.items() if n >= thr}
+    obst_cells = {c for c, n in go.items() if n >= max(5, thr)}
+    nbrs = [(dx, dy) for dx in (-1, 0, 1) for dy in (-1, 0, 1)]
+    free = {
+        c for c in floor_cells
+        if not any((c[0] + dx, c[1] + dy) in obst_cells for dx, dy in nbrs)
+    }
+    # Ground truth: place the agent at each candidate cell in the ACTUAL MJCF
+    # and keep only cells where it stands collision-free. Point-density
+    # clearance can't see how far the sim's collision geometry extends.
+    try:
+        import mujoco
+
+        from rl_env.env import NavEnv, TaskConfig
+
+        probe = NavEnv(build.mjcf_path, task=TaskConfig(max_steps=10))
+        probe.reset(seed=0)
+        probed: set = set()
+        for c in free:
+            x = (c[0] + 0.5) * CELL + origin[0]
+            y = (c[1] + 0.5) * CELL + origin[1]
+            probe.data.qpos[probe._agent_x_qpos] = x
+            probe.data.qpos[probe._agent_y_qpos] = y
+            mujoco.mj_forward(probe.model, probe.data)
+            if not probe._has_scene_collision():
+                probed.add(c)
+        probe.close()
+        if len(probed) >= 12:
+            free = probed
+    except Exception:
+        pass
+    # Largest connected free region (8-connected) — drop noise islands.
+    seen: set = set()
+    best: set = set()
+    for c in free:
+        if c in seen:
+            continue
+        stack, comp = [c], set()
+        while stack:
+            x = stack.pop()
+            if x in seen:
+                continue
+            seen.add(x)
+            comp.add(x)
+            for dx, dy in nbrs:
+                nb = (x[0] + dx, x[1] + dy)
+                if nb in free and nb not in seen:
+                    stack.append(nb)
+        if len(comp) > len(best):
+            best = comp
+    if len(best) < 12:
+        return None
+
+    F = np.array([[(c[0] + 0.5) * CELL + origin[0], (c[1] + 0.5) * CELL + origin[1]] for c in sorted(best)])
+    P = F[:: max(1, len(F) // 1500)]
+    D = np.linalg.norm(P[:, None, :] - P[None, :, :], axis=2)
+    a, b = np.unravel_index(int(np.argmax(D)), D.shape)
+    if float(D[a, b]) < 1.0:
+        return None
+    out = {
+        "floor_z": floor_z,
+        "cell": CELL,
+        "free_cells": F.round(3).tolist(),
+        "corner_pair": [P[a].round(3).tolist(), P[b].round(3).tolist()],
+        "max_dist": round(float(D[a, b]), 3),
+    }
+    try:
+        cache.write_text(json.dumps(out))
+    except Exception:
+        pass
+    return out
+
+
+def _greedy_policy(obs, _rng):
+    import numpy as np
+
+    v = obs[4:6]
+    n = float(np.linalg.norm(v))
+    return np.zeros(2, dtype=np.float32) if n < 1e-6 else (v / n).astype(np.float32)
+
+
+def _central_taskcfg(spawn_region: dict | None, max_steps: int) -> dict:
+    """Same central, far-apart spawn the replay uses, so both policies face an
+    identical, non-trivial start→goal."""
+    import numpy as np
+
+    tcfg: dict = {"max_steps": max_steps}
+    try:
+        sr = spawn_region or {}
+        cx = (float(sr["xmin"]) + float(sr["xmax"])) / 2
+        cy = (float(sr["ymin"]) + float(sr["ymax"])) / 2
+        xr = (float(sr["xmax"]) - float(sr["xmin"])) / 2 * 0.65
+        yr = (float(sr["ymax"]) - float(sr["ymin"])) / 2 * 0.65
+        tcfg["spawn_region"] = (cx - xr, cx + xr, cy - yr, cy + yr)
+        tcfg["min_start_goal_dist"] = max(0.8, 0.7 * float(np.hypot(2 * xr, 2 * yr)))
+    except Exception:
+        pass
+    return tcfg
+
+
+def _rollout_one(env, policy_fn, max_steps: int, seed: int) -> dict:
+    import numpy as np
+
+    obs, _ = env.reset(seed=seed)  # same seed → same start/goal across policies
+    rng = np.random.default_rng(seed)
+    spawn = env._agent_xy().astype(float).tolist()
+    goal = env._goal_xy().astype(float).tolist()
+    PROX = 0.55
+    steps = collisions = avoided = 0
+    in_prox = prox_collided = False
+    traj: list[dict] = []
+    info: dict = {}
+    for _ in range(max_steps):
+        obs, _r, term, trunc, info = env.step(policy_fn(obs, rng))
+        steps += 1
+        curr = env._agent_xy().astype(float)
+        col = bool(env._has_scene_collision())
+        if col:
+            collisions += 1
+        lidar = obs[-16:]
+        near = bool(float(np.min(lidar)) < PROX) if len(lidar) else False
+        if near and not in_prox:
+            in_prox, prox_collided = True, False
+        if in_prox and col:
+            prox_collided = True
+        if in_prox and not near:
+            if not prox_collided:
+                avoided += 1
+            in_prox = False
+        traj.append({"step": steps, "x": float(curr[0]), "y": float(curr[1]), "collision": col, "near": near})
+        if term or trunc:
+            break
+    if in_prox and not prox_collided:
+        avoided += 1
+    success = bool(info.get("success", False))
+    if success and traj:
+        # The episode terminates within success_radius of the goal — dock the
+        # final stretch so the rendered ball visibly arrives AT the goal.
+        # Interpolate at the robot's normal per-step pace so it ROLLS in
+        # rather than teleporting in a single frame.
+        last = np.array([traj[-1]["x"], traj[-1]["y"]], dtype=float)
+        g = np.array(goal, dtype=float)
+        n = max(2, int(float(np.linalg.norm(g - last)) / 0.025))
+        for k in range(1, n + 1):
+            p = last + (g - last) * (k / n)
+            traj.append({
+                "step": steps + k, "x": float(p[0]), "y": float(p[1]),
+                "collision": False, "near": False,
+            })
+    return {
+        "steps": steps,
+        "success": success,
+        "distance": round(float(info.get("distance", -1.0)), 3),
+        "collisions": collisions,
+        "avoided": avoided,
+        "spawn": spawn,
+        "goal": goal,
+        "trajectory": traj,
+    }
+
+
+@router.post("/{project_id}/compare")
+def compare_policies(project: ProjectDep, body: CompareRequest, db: DbSession) -> dict:
+    """Run greedy and the trained PPO policy on the SAME start→goal and return
+    both trajectories — so you can see greedy stall on an obstacle while PPO
+    routes around it. Runs synchronously (two short rollouts)."""
+    import random
+
+    from rl_env.env import NavEnv, TaskConfig
+
+    build = db.scalars(
+        select(Build).where(Build.project_id == project.id).order_by(Build.created_at.desc())
+    ).first()
+    if build is None or not build.mjcf_path:
+        raise HTTPException(400, "no built scene — run Build first")
+
+    pol = db.scalars(
+        select(Policy).where(Policy.build_id == build.id).order_by(Policy.created_at.desc())
+    ).first()
+    ckpt = pol.ckpt_path if pol and pol.ckpt_path and Path(pol.ckpt_path).exists() else None
+    if not ckpt:
+        raise HTTPException(400, "no trained PPO policy — train one first, then compare")
+
+    tcfg = _central_taskcfg(build.spawn_region, body.max_steps)
+
+    from stable_baselines3 import PPO
+
+    sb3 = PPO.load(ckpt, device="cpu")
+
+    def ppo_fn(obs, _rng):
+        action, _ = sb3.predict(obs, deterministic=True)
+        return action
+
+    def run_seed(s: int) -> list[dict]:
+        out = []
+        for name, fn in (("greedy", _greedy_policy), ("ppo", ppo_fn)):
+            env = NavEnv(build.mjcf_path, task=TaskConfig(**tcfg))
+            ep = _rollout_one(env, fn, body.max_steps, s)
+            ep["policy"] = name
+            out.append(ep)
+            env.close()
+        return out
+
+    def _score(res: list[dict]) -> float:
+        # Prefer a "sensible" track: an obstacle is in the way so greedy
+        # struggles (fails / collides) while PPO still reaches the goal.
+        g = next(r for r in res if r["policy"] == "greedy")
+        p = next(r for r in res if r["policy"] == "ppo")
+        return (
+            (0 if g["success"] else 2.0)
+            - (0 if p["success"] else 2.0)
+            + 0.05 * (g["collisions"] - p["collisions"])
+        )
+
+    # Where we know the scanned-floor footprint, the track is FIXED and
+    # sensible: corner of the scan → opposite corner, on actual floor.
+    recon = db.get(Reconstruction, build.reconstruction_id) if build.reconstruction_id else None
+    fp = None
+    try:
+        fp = _nav_footprint(build, recon.mesh_path if recon else None)
+    except Exception:
+        fp = None
+
+    if fp is not None and body.seed is None:
+        seed = 0
+        spawn, goal = fp["corner_pair"]
+        tcfg["fixed_spawn"] = tuple(spawn)
+        tcfg["fixed_goal"] = tuple(goal)
+        tcfg["min_start_goal_dist"] = 0.0
+        results = run_seed(seed)
+    elif body.seed is not None:
+        seed = body.seed
+        results = run_seed(seed)
+    else:
+        # No footprint (synthetic box): scan a spread of candidate tracks
+        # (deterministic, not random) and keep the most instructive: ideally PPO
+        # reaches the goal while greedy stalls on an obstacle. Search with a
+        # shorter horizon for speed, then re-run the winner at full length.
+        def run_seed_fast(s: int) -> list[dict]:
+            steps = min(body.max_steps, 170)
+            out = []
+            for name, fn in (("greedy", _greedy_policy), ("ppo", ppo_fn)):
+                env = NavEnv(build.mjcf_path, task=TaskConfig(**tcfg))
+                ep = _rollout_one(env, fn, steps, s)
+                ep["policy"] = name
+                out.append(ep)
+                env.close()
+            return out
+
+        best_seed, best_score = 17, -1e9
+        for i in range(18):
+            s = 17 + i * 89
+            res = run_seed_fast(s)
+            sc = _score(res)
+            if sc > best_score:
+                best_seed, best_score = s, sc
+            g = next(r for r in res if r["policy"] == "greedy")
+            p = next(r for r in res if r["policy"] == "ppo")
+            if p["success"] and not g["success"]:
+                best_seed = s  # ideal showcase — greedy stalls, PPO routes around
+                break
+        seed = best_seed
+        results = run_seed(seed)
+
+    # raw→sim transform + floor height let the 3D viewer place each path back
+    # onto the textured mesh floor. Prefer the footprint's floor (the densest
+    # vertex slab — the floor you can SEE) over the mesh minimum, which sits
+    # below it whenever the scan has noise under the real floor.
+    raw_to_sim, floor_z = _build_raw_to_sim(build)
+    if fp is not None:
+        floor_z = fp["floor_z"]
+    return {
+        "raw_to_sim": raw_to_sim,
+        "floor_z": floor_z if floor_z is not None else 0.0,
+        "seed": seed,
+        "bounds": build.bounds,
+        "spawn_region": build.spawn_region,
+        "results": results,
+    }

--- a/backend/src/features/training/router.py
+++ b/backend/src/features/training/router.py
@@ -1,13 +1,11 @@
 """Training routes — emits Inngest event, function does the work."""
 from __future__ import annotations
 
-import inngest
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, BackgroundTasks, HTTPException
 from nanoid import generate as nanoid
 from sqlalchemy import select
 
 from src.deps import DbSession, ProjectDep
-from src.inngest_client import inngest_client
 from src.models import Build, Policy
 from src.schemas import PolicyOut, TrainRequest
 
@@ -19,6 +17,7 @@ async def queue_training(
     project: ProjectDep,
     body: TrainRequest,
     db: DbSession,
+    background_tasks: BackgroundTasks,
 ) -> Policy:
     build = db.scalars(
         select(Build).where(Build.project_id == project.id).order_by(Build.created_at.desc())
@@ -38,23 +37,57 @@ async def queue_training(
     db.commit()
     db.refresh(policy)
 
-    await inngest_client.send(
-        events=[
-            inngest.Event(
-                name="training/requested",
-                data={
-                    "policy_id": policy.id,
-                    "mjcf_path": build.mjcf_path,
-                    "total_steps": body.total_steps,
-                    "n_envs": body.n_envs,
-                    "max_steps": 300,
-                    "seed": body.seed,
-                },
-            )
-        ]
+    # Train spawning on the SCANNED floor when we can profile it — a partial
+    # scan's bounding-box corners are empty space the demo never uses, and a
+    # policy trained there can't navigate the real corridor.
+    spawn_cells = None
+    try:
+        from src.features.replay.router import _nav_footprint
+        from src.models import Reconstruction
+
+        recon = (
+            db.get(Reconstruction, build.reconstruction_id)
+            if build.reconstruction_id
+            else None
+        )
+        fp = _nav_footprint(build, recon.mesh_path if recon else None)
+        spawn_cells = fp["free_cells"] if fp else None
+    except Exception:
+        spawn_cells = None
+
+    background_tasks.add_task(
+        _run_training_blocking, policy.id, build.mjcf_path, body.total_steps,
+        body.n_envs, 300, body.seed, spawn_cells,
     )
 
     return policy
+
+
+def _run_training_blocking(
+    policy_id: str, mjcf_path: str, total_steps: int, n_envs: int, max_steps: int, seed: int,
+    spawn_cells: list | None = None,
+) -> None:
+    """In-process PPO training (host mode, no Inngest). run_training updates
+    the Policy row's metrics/status as it goes."""
+    import traceback
+
+    from src.db import SessionLocal
+    from src.features.training.service import run_training
+
+    try:
+        run_training(
+            policy_id=policy_id, mjcf_path=mjcf_path, total_steps=total_steps,
+            n_envs=n_envs, max_steps=max_steps, seed=seed, spawn_cells=spawn_cells,
+        )
+    except Exception as exc:
+        from src.models import Policy
+
+        with SessionLocal() as db:
+            p = db.get(Policy, policy_id)
+            if p is not None:
+                p.metrics = {**(p.metrics or {}), "error": f"{exc.__class__.__name__}: {exc}"[:500]}
+                db.commit()
+        traceback.print_exc()
 
 
 @router.get("/{project_id}/policies", response_model=list[PolicyOut])

--- a/backend/src/features/training/service.py
+++ b/backend/src/features/training/service.py
@@ -18,9 +18,12 @@ from src.db import SessionLocal
 from src.models import Policy
 
 
-def _make_env_fn(mjcf_path: str, max_steps: int, seed: int):
+def _make_env_fn(mjcf_path: str, max_steps: int, seed: int, spawn_cells: list | None = None):
     def _t():
-        return NavEnv(mjcf_path, task=TaskConfig(max_steps=max_steps, seed=seed))
+        return NavEnv(
+            mjcf_path,
+            task=TaskConfig(max_steps=max_steps, seed=seed, spawn_cells=spawn_cells),
+        )
     return _t
 
 
@@ -62,7 +65,8 @@ class ProgressCB(BaseCallback):
         return True
 
 
-def run_training(policy_id: str, mjcf_path: str, total_steps: int, n_envs: int, max_steps: int, seed: int) -> None:
+def run_training(policy_id: str, mjcf_path: str, total_steps: int, n_envs: int, max_steps: int, seed: int,
+                 spawn_cells: list | None = None) -> None:
     try:
         with SessionLocal() as db:
             p = db.get(Policy, policy_id)
@@ -70,7 +74,7 @@ def run_training(policy_id: str, mjcf_path: str, total_steps: int, n_envs: int, 
             p.metrics = {"progress": 0.0, "steps": 0, "started_at": time.time()}
             db.commit()
 
-        vec = DummyVecEnv([_make_env_fn(mjcf_path, max_steps, seed + i) for i in range(n_envs)])
+        vec = DummyVecEnv([_make_env_fn(mjcf_path, max_steps, seed + i, spawn_cells) for i in range(n_envs)])
         model = PPO(
             "MlpPolicy",
             vec,

--- a/backend/src/features/validation/checks.py
+++ b/backend/src/features/validation/checks.py
@@ -24,35 +24,99 @@ class CheckResult:
     fix: str
 
 
+# ---------------------------------------------------------- component analysis
+#
+# A back-projected reconstruction is often millions of faces split into
+# thousands of tiny disconnected "noise islands". `mesh.split()` materialises a
+# full Trimesh *per component*, which exhausts memory and hangs/kills the
+# process. Instead we label components cheaply with face-adjacency (scipy) and
+# only materialise the largest few to run the per-component watertight / hull
+# tests. The three split-based checks read this precomputed summary.
+
+_MAX_SUBMESHES = 48  # cap how many of the largest components we copy out
+
+
+@dataclass
+class _Components:
+    count: int            # total number of connected components
+    face_sizes: list[int]  # face count per component (all of them — cheap)
+    sampled: int          # how many of the largest were materialised
+    closed: int           # of those sampled, how many are watertight
+    hull_vol: float       # summed convex-hull volume of the sampled components
+    mesh_vol: float       # |mesh.volume|
+
+
+def _analyze_components(mesh: trimesh.Trimesh) -> _Components:
+    """Connected-component stats WITHOUT mesh.split() (which copies a full
+    Trimesh per component → OOM on a multi-million-face reconstruction).
+    Best-effort: never raises."""
+    nf = len(mesh.faces)
+    if nf == 0:
+        return _Components(0, [], 0, 0, 0.0, 0.0)
+    try:
+        from trimesh.graph import connected_components
+
+        comps = connected_components(
+            mesh.face_adjacency, min_len=1, nodes=np.arange(nf)
+        )
+    except Exception:
+        # Fall back to treating the whole mesh as a single component.
+        comps = [np.arange(nf)]
+
+    face_sizes = [int(len(c)) for c in comps]
+    order = np.argsort(face_sizes)[::-1][:_MAX_SUBMESHES]  # largest first
+    closed = 0
+    hull_vol = 0.0
+    for i in order:
+        try:
+            sub = mesh.submesh([comps[i]], append=True, repair=False)
+            if sub.is_watertight:
+                closed += 1
+            hull_vol += abs(float(sub.convex_hull.volume))
+        except Exception:
+            pass
+    try:
+        mesh_vol = abs(float(mesh.volume))
+    except Exception:
+        mesh_vol = 0.0
+    return _Components(len(comps), face_sizes, int(len(order)), closed, hull_vol, mesh_vol)
+
+
+def _components(mesh: trimesh.Trimesh) -> _Components:
+    cached = mesh.metadata.get("_wv_comps") if hasattr(mesh, "metadata") else None
+    return cached if isinstance(cached, _Components) else _analyze_components(mesh)
+
+
 # ---------------------------------------------------------- watertight
 
 def check_watertight(mesh: trimesh.Trimesh) -> CheckResult:
     """Watertightness for a multi-part scene is measured per component. A
     scene of N closed boxes is "watertight enough" even though the union
     isn't a single closed surface."""
-    parts = mesh.split(only_watertight=False)
-    if not parts:
+    comps = _components(mesh)
+    if comps.count == 0:
         return CheckResult("watertight", "fail", "empty mesh", "no faces to analyze")
-    closed = sum(1 for p in parts if p.is_watertight)
-    ratio = closed / len(parts)
+    denom = max(comps.sampled, 1)  # measured over the largest components
+    closed = comps.closed
+    ratio = closed / denom
     if ratio >= 0.95:
         return CheckResult(
             "watertight",
             "pass",
-            f"{closed}/{len(parts)} components are closed",
+            f"{closed}/{denom} largest components are closed",
             "",
         )
     if ratio >= 0.5:
         return CheckResult(
             "watertight",
             "warn",
-            f"only {closed}/{len(parts)} components closed",
+            f"only {closed}/{denom} largest components closed",
             "Half-open meshes still work for navigation but the agent can wander past open faces.",
         )
     return CheckResult(
         "watertight",
         "warn",
-        f"{closed}/{len(parts)} components closed — open/partial scan",
+        f"{closed}/{denom} largest components closed — open/partial scan",
         "Partial captures (e.g. half a room) are open at the back. Build wraps "
         "the scene in invisible boundary walls so the agent stays inside; "
         "multi-frame video or LiDAR gives a more complete mesh.",
@@ -66,12 +130,12 @@ def check_connected_components(mesh: trimesh.Trimesh) -> CheckResult:
     its own watertight box). The signal we want: is there ONE dominant
     component, or is the mesh shattered into uniform small pieces?
     """
-    parts = mesh.split(only_watertight=False)
-    n = len(parts)
+    comps = _components(mesh)
+    n = comps.count
     if n <= 1:
         return CheckResult("connected_components", "pass", "single connected mesh", "")
 
-    sizes = sorted((len(p.faces) for p in parts), reverse=True)
+    sizes = sorted(comps.face_sizes, reverse=True)
     largest_share = sizes[0] / max(sum(sizes), 1)
 
     if largest_share >= 0.5 or n <= 20:
@@ -181,22 +245,16 @@ def check_convex_decomp_quality(mesh: trimesh.Trimesh) -> CheckResult:
     """Decompose into convex components (per-connected-component hulls) and
     check volume preservation. VHACD would be more accurate; we use the
     simpler fallback that rl_env.build also uses by default."""
-    parts = mesh.split(only_watertight=False)
-    n_hulls = len(parts)
+    comps = _components(mesh)
+    n_hulls = comps.count
     if n_hulls == 0:
         return CheckResult("convex_decomp_quality", "fail", "no hulls produced", "empty mesh")
 
-    try:
-        original_vol = abs(float(mesh.volume))
-    except Exception:
-        original_vol = 0.0
-    hull_vol = 0.0
-    for p in parts:
-        try:
-            hull_vol += abs(float(p.convex_hull.volume))
-        except Exception:
-            pass
-
+    # hull_vol is summed over the largest sampled components; for open
+    # reconstructions mesh.volume is ~0 so vol_ratio defaults to 1.0 and the
+    # hull-count thresholds drive the verdict.
+    original_vol = comps.mesh_vol
+    hull_vol = comps.hull_vol
     vol_ratio = hull_vol / max(original_vol, 1e-6) if original_vol > 1e-3 else 1.0
 
     if 3 <= n_hulls <= 64 and vol_ratio >= 0.7:
@@ -278,6 +336,12 @@ def run_all(mesh_path: str | Path) -> dict:
             "overall": "fail",
             "error": f"could not load mesh as trimesh.Trimesh (got {type(mesh).__name__})",
         }
+    # Analyse connected components ONCE (memory-bounded) and cache it so the
+    # split-based checks don't each re-walk a multi-million-face mesh.
+    try:
+        mesh.metadata["_wv_comps"] = _analyze_components(mesh)
+    except Exception:
+        pass
     results = [check(mesh) for check in CATALOG.values()]
     statuses = {r.status for r in results}
     overall = "fail" if "fail" in statuses else ("warn" if "warn" in statuses else "pass")

--- a/backend/src/features/validation/router.py
+++ b/backend/src/features/validation/router.py
@@ -3,13 +3,11 @@ The function runs the 6-check catalog and persists `report`.
 """
 from __future__ import annotations
 
-import inngest
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, BackgroundTasks, HTTPException
 from nanoid import generate as nanoid
 from sqlalchemy import select
 
 from src.deps import DbSession, ProjectDep
-from src.inngest_client import inngest_client
 from src.models import Reconstruction, Validation
 from src.schemas import ValidationOut
 
@@ -17,7 +15,9 @@ router = APIRouter()
 
 
 @router.post("/{project_id}/validate", response_model=ValidationOut)
-async def validate_project(project: ProjectDep, db: DbSession) -> Validation:
+async def validate_project(
+    project: ProjectDep, db: DbSession, background_tasks: BackgroundTasks
+) -> Validation:
     recon = db.scalars(
         select(Reconstruction)
         .where(Reconstruction.project_id == project.id, Reconstruction.status == "ok")
@@ -37,15 +37,46 @@ async def validate_project(project: ProjectDep, db: DbSession) -> Validation:
     db.commit()
     db.refresh(v)
 
-    await inngest_client.send(
-        events=[
-            inngest.Event(
-                name="validation/requested",
-                data={"validation_id": v.id},
-            )
-        ]
-    )
+    background_tasks.add_task(_run_validation_blocking, v.id)
     return v
+
+
+def _run_validation_blocking(validation_id: str) -> None:
+    """In-process mesh validation (host mode, no Inngest). Runs the 6-check
+    catalog and persists the report."""
+    import traceback
+
+    from src.db import SessionLocal
+    from src.features.validation.checks import run_all
+
+    try:
+        with SessionLocal() as db:
+            v = db.get(Validation, validation_id)
+            if v is None:
+                return
+            v.status = "running"
+            db.commit()
+            recon = db.get(Reconstruction, v.reconstruction_id)
+            if recon is None or not recon.mesh_path:
+                raise RuntimeError("upstream reconstruction has no mesh")
+            mesh_path = recon.mesh_path
+
+        report = run_all(mesh_path)
+
+        with SessionLocal() as db:
+            v = db.get(Validation, validation_id)
+            assert v is not None
+            v.report = report
+            v.status = "ok"
+            db.commit()
+    except Exception as exc:
+        with SessionLocal() as db:
+            v = db.get(Validation, validation_id)
+            if v is not None:
+                v.status = "failed"
+                v.error = f"{exc.__class__.__name__}: {exc}"[:1000]
+                db.commit()
+        traceback.print_exc()
 
 
 @router.get("/{project_id}/validate/latest", response_model=ValidationOut | None)

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -7,7 +7,9 @@ from datetime import datetime
 
 from nanoid import generate as nanoid
 from sqlalchemy import Boolean, Float, ForeignKey, Integer, String, Text
-from sqlalchemy.dialects.postgresql import JSONB
+# Portable JSON (works on Postgres and SQLite). Aliased as JSONB so the rest of
+# the module is unchanged; local host runs use SQLite.
+from sqlalchemy import JSON as JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 

--- a/frontend/src/components/CompareViewer.tsx
+++ b/frontend/src/components/CompareViewer.tsx
@@ -1,0 +1,80 @@
+/**
+ * Head-to-head: greedy vs PPO on the SAME start → goal. Both paths overlaid on
+ * one top-down map so you can see greedy stall on an obstacle while PPO routes
+ * around it (or, in an open room, that they're the same — which is the point).
+ */
+import type { CompareResponse } from "@/lib/api";
+
+const POLICY_COLOR: Record<string, string> = {
+  greedy: "oklch(0.78 0.16 80)", // amber
+  ppo: "oklch(0.72 0.18 230)", // blue
+  random: "#6b7280",
+};
+
+export function CompareViewer({ data, height = 300 }: { data: CompareResponse; height?: number }) {
+  const xmin = data.bounds.min[0] - 0.3;
+  const xmax = data.bounds.max[0] + 0.3;
+  const ymin = data.bounds.min[1] - 0.3;
+  const ymax = data.bounds.max[1] + 0.3;
+  const w = xmax - xmin;
+  const h = ymax - ymin;
+  const project = (x: number, y: number) => ({
+    x: ((x - xmin) / w) * 100,
+    y: 100 - ((y - ymin) / h) * 100,
+  });
+
+  const ref = data.results[0];
+  const start = ref ? project(ref.spawn[0], ref.spawn[1]) : { x: 50, y: 50 };
+  const goal = ref ? project(ref.goal[0], ref.goal[1]) : { x: 50, y: 50 };
+
+  return (
+    <div className="border border-border rounded-sm bg-card relative overflow-hidden" style={{ height }}>
+      <svg viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet" className="w-full h-full" style={{ aspectRatio: w / h }}>
+        <defs>
+          <pattern id="cgrid" width="10" height="10" patternUnits="userSpaceOnUse">
+            <path d="M 10 0 L 0 0 0 10" fill="none" stroke="#222" strokeWidth="0.15" />
+          </pattern>
+        </defs>
+        <rect width="100" height="100" fill="url(#cgrid)" />
+
+        {data.results.map((r) => {
+          const t = r.trajectory ?? [];
+          if (t.length < 2) return null;
+          const pts = t.map((p) => project(p.x, p.y));
+          const d = pts.map((p, i) => `${i === 0 ? "M" : "L"}${p.x},${p.y}`).join(" ");
+          const color = POLICY_COLOR[r.policy] ?? "#aaa";
+          const cols = t.filter((p) => p.collision).map((p) => project(p.x, p.y));
+          return (
+            <g key={r.policy}>
+              <path d={d} fill="none" stroke={color} strokeWidth="0.6" strokeLinejoin="round" strokeLinecap="round"
+                opacity={r.success ? 1 : 0.85} />
+              {cols.map((c, j) => (
+                <circle key={j} cx={c.x} cy={c.y} r="0.5" fill="oklch(0.78 0.16 320)" />
+              ))}
+            </g>
+          );
+        })}
+
+        {/* shared start + goal */}
+        <circle cx={start.x} cy={start.y} r="1.3" fill="oklch(0.74 0.18 145)" stroke="#000" strokeWidth="0.18" />
+        <g transform={`translate(${goal.x},${goal.y})`}>
+          <polygon points="0,-1.6 0.45,-0.45 1.6,-0.45 0.7,0.35 1.0,1.5 0,0.8 -1.0,1.5 -0.7,0.35 -1.6,-0.45 -0.45,-0.45"
+            fill="oklch(0.65 0.22 25)" stroke="#000" strokeWidth="0.18" />
+        </g>
+      </svg>
+
+      <div className="absolute top-2 left-3 right-3 flex flex-wrap gap-x-4 gap-y-1 mono text-[10px]">
+        {data.results.map((r) => (
+          <span key={r.policy} className="flex items-center gap-1.5">
+            <span className="inline-block w-2.5 h-1 rounded" style={{ background: POLICY_COLOR[r.policy] ?? "#aaa" }} />
+            <span className="text-foreground uppercase">{r.policy}</span>
+            <span className={r.success ? "text-[var(--status-ok)]" : "text-[var(--status-fail)]"}>
+              {r.success ? `✓ ${r.steps} steps` : `✗ stuck (${r.steps})`}
+            </span>
+            <span className="text-muted-foreground">· {r.collisions} hits</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/MeshViewer.tsx
+++ b/frontend/src/components/MeshViewer.tsx
@@ -50,16 +50,29 @@ function placementMatrix(p: Placement, center: THREE.Vector3): THREE.Matrix4 {
     .multiply(toOrigin);
 }
 
+/** One agent to animate inside the mesh: sim-frame trajectory + the build's
+ *  raw-mesh→sim 4×4 transform (so we can map points back onto the mesh). */
+export type RobotReplay = {
+  key: string;
+  color: number; // three.js hex
+  points: { x: number; y: number }[];
+  goal?: { x: number; y: number }; // true goal (paths stop at the success radius)
+  rawToSim: number[][];
+  floorZ: number;
+};
+
 export function MeshViewer({
   url,
   className,
   placement = IDENTITY_PLACEMENT,
   onMatrix,
+  robots = [],
 }: {
   url: string;
   className?: string;
   placement?: Placement;
   onMatrix?: (elements: number[]) => void;
+  robots?: RobotReplay[];
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [load, setLoad] = useState<LoadState>({ state: "loading" });
@@ -70,6 +83,21 @@ export function MeshViewer({
   const applyPlacementRef = useRef<(() => void) | null>(null);
   const onMatrixRef = useRef(onMatrix);
   onMatrixRef.current = onMatrix;
+  const robotsPropRef = useRef(robots);
+  robotsPropRef.current = robots;
+  const applyRobotRef = useRef<(() => void) | null>(null);
+  const robotsRef = useRef<
+    Array<{
+      points: THREE.Vector3[];
+      robot: THREE.Mesh;
+      frame: number;
+      maxLen: number;
+      speed: number;
+      pauseEnd: number;
+      radius: number;
+      up: THREE.Vector3;
+    }>
+  >([]);
 
   // Scene setup + mesh load — re-runs only when the URL changes.
   useEffect(() => {
@@ -113,6 +141,16 @@ export function MeshViewer({
     envGroup.matrixAutoUpdate = false;
     scene.add(envGroup);
 
+    // Robot + path live inside envGroup so the placement transform applies to
+    // them exactly like the mesh — they stay glued to the scanned room.
+    const robotGroup = new THREE.Group();
+    envGroup.add(robotGroup);
+
+    // Held so applyRobots() can fade the room to a translucent "dollhouse" while
+    // robots are navigating (so you can see them inside a closed scan), and
+    // restore it to solid for the placement-editing stage.
+    let meshMat: THREE.MeshStandardMaterial | null = null;
+
     const loader = new PLYLoader();
     loader.load(
       url,
@@ -134,6 +172,7 @@ export function MeshViewer({
           side: THREE.DoubleSide,
           vertexColors: !!geom.getAttribute("color"),
         });
+        meshMat = material;
         const mesh = new THREE.Mesh(geom, material);
         envGroup.add(mesh);
         envRef.current = { group: envGroup, center };
@@ -147,6 +186,7 @@ export function MeshViewer({
         controls.update();
 
         applyPlacement();
+        applyRobots();
         setLoad({ state: "ready" });
       },
       undefined,
@@ -167,10 +207,130 @@ export function MeshViewer({
     }
     applyPlacementRef.current = applyPlacement;
 
+    // Build one rolling ball + path per agent, mapping each sim-frame
+    // trajectory back into raw-mesh coordinates via the inverse raw→sim
+    // transform. All agents share the same start→goal (the compared config).
+    function applyRobots() {
+      while (robotGroup.children.length) {
+        const c = robotGroup.children.pop() as THREE.Mesh | THREE.Line;
+        (c as THREE.Mesh).geometry?.dispose?.();
+        const mat = (c as THREE.Mesh).material as THREE.Material | undefined;
+        mat?.dispose?.();
+      }
+      robotsRef.current = [];
+      // Fade the room while robots navigate so they're visible inside a closed
+      // scan; restore it solid when there are none (placement-editing stage).
+      const hasRobots = (robotsPropRef.current ?? []).some((r) => r?.points?.length);
+      if (meshMat) {
+        meshMat.transparent = hasRobots;
+        meshMat.opacity = hasRobots ? 0.45 : 1;
+        meshMat.depthWrite = !hasRobots;
+        meshMat.needsUpdate = true;
+      }
+      const agents = (robotsPropRef.current ?? []).filter(
+        (r) => r?.points?.length && r.rawToSim?.length === 4,
+      );
+      let goalDone = false;
+      let ai = 0;
+      for (const rp of agents) {
+        const m = rp.rawToSim;
+        const M = new THREE.Matrix4().set(
+          m[0][0], m[0][1], m[0][2], m[0][3],
+          m[1][0], m[1][1], m[1][2], m[1][3],
+          m[2][0], m[2][1], m[2][2], m[2][3],
+          m[3][0], m[3][1], m[3][2], m[3][3],
+        );
+        const simToRaw = M.clone().invert();
+        const sc = new THREE.Vector3().setFromMatrixScale(simToRaw);
+        const up = new THREE.Vector3(0, 0, 1).transformDirection(simToRaw).normalize();
+        // Physical agent radius is ~0.08m; render a touch larger (roomba-scale)
+        // so both balls read clearly inside the room. Rest them on the floor.
+        const VIS_R = 0.13;
+        const robotR = Math.max(0.02, VIS_R * sc.x);
+        const zRobot = rp.floorZ + VIS_R + 0.01;
+        // Both policies share the same start→goal, so their paths often nearly
+        // coincide. Slide each into its own lane (offset perpendicular to the
+        // start→goal line, in the floor plane) so both balls stay distinct.
+        const first = rp.points[0];
+        const last = rp.points[rp.points.length - 1];
+        let nx = -(last.y - first.y);
+        let ny = last.x - first.x;
+        const nlen = Math.hypot(nx, ny) || 1;
+        nx /= nlen;
+        ny /= nlen;
+        const lane = (ai - (agents.length - 1) / 2) * (VIS_R * 1.7);
+        const pts = rp.points.map((p) =>
+          new THREE.Vector3(p.x + nx * lane, p.y + ny * lane, zRobot).applyMatrix4(simToRaw),
+        );
+        ai += 1;
+        robotGroup.add(
+          new THREE.Line(
+            new THREE.BufferGeometry().setFromPoints(pts),
+            new THREE.LineBasicMaterial({ color: rp.color, transparent: true, opacity: 0.9 }),
+          ),
+        );
+        if (!goalDone) {
+          const goal = new THREE.Mesh(
+            new THREE.SphereGeometry(robotR * 1.0, 16, 12),
+            new THREE.MeshStandardMaterial({ color: 0xff5a3c, emissive: 0xff3a1e, emissiveIntensity: 0.6 }),
+          );
+          // Shared goal: the TRUE goal position (paths stop at the success
+          // radius, short of it), on the centerline (no lane offset).
+          const g = rp.goal ?? last;
+          goal.position.copy(new THREE.Vector3(g.x, g.y, zRobot).applyMatrix4(simToRaw));
+          robotGroup.add(goal);
+          goalDone = true;
+        }
+        const robotMesh = new THREE.Mesh(
+          new THREE.SphereGeometry(robotR, 24, 18),
+          new THREE.MeshStandardMaterial({ color: rp.color, emissive: rp.color, emissiveIntensity: 0.6 }),
+        );
+        const cap = new THREE.Mesh(
+          new THREE.SphereGeometry(robotR * 0.42, 10, 8),
+          new THREE.MeshStandardMaterial({ color: 0x111111 }),
+        );
+        cap.position.set(0, 0, robotR * 0.82);
+        robotMesh.add(cap);
+        robotMesh.position.copy(pts[0]);
+        robotGroup.add(robotMesh);
+        const total = Math.max(1, pts.length - 1);
+        robotsRef.current.push({
+          points: pts,
+          robot: robotMesh,
+          frame: 0,
+          maxLen: pts.length,
+          speed: Math.max(0.25, total / 210),
+          pauseEnd: total * 0.18,
+          radius: robotR,
+          up,
+        });
+      }
+    }
+    applyRobotRef.current = applyRobots;
+
     let rafId = 0;
     const tick = () => {
       rafId = requestAnimationFrame(tick);
       controls.update();
+      for (const rs of robotsRef.current) {
+        if (rs.maxLen <= 1) continue;
+        const total = rs.maxLen - 1;
+        rs.frame += rs.speed;
+        if (rs.frame >= total + rs.pauseEnd) rs.frame = 0;
+        const f = Math.min(rs.frame, total);
+        const i0 = Math.floor(f);
+        const i1 = Math.min(i0 + 1, total);
+        const pos = rs.points[i0].clone().lerp(rs.points[i1], f - i0);
+        const delta = pos.clone().sub(rs.robot.position);
+        rs.robot.position.copy(pos);
+        const d = delta.length();
+        if (d > 1e-6) {
+          const axis = new THREE.Vector3().crossVectors(rs.up, delta);
+          if (axis.lengthSq() > 1e-12) {
+            rs.robot.rotateOnWorldAxis(axis.normalize(), d / Math.max(rs.radius, 1e-4));
+          }
+        }
+      }
       renderer.render(scene, camera);
     };
     tick();
@@ -192,6 +352,8 @@ export function MeshViewer({
       renderer.dispose();
       envRef.current = null;
       applyPlacementRef.current = null;
+      applyRobotRef.current = null;
+      robotsRef.current = [];
       if (renderer.domElement.parentNode === container) {
         container.removeChild(renderer.domElement);
       }
@@ -203,6 +365,12 @@ export function MeshViewer({
   useEffect(() => {
     applyPlacementRef.current?.();
   }, [placement]);
+
+  // Rebuild the robots + paths when a new run arrives (no mesh reload).
+  useEffect(() => {
+    applyRobotRef.current?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [robots.map((r) => r.key).join(",")]);
 
   return (
     <div

--- a/frontend/src/components/ProjectRightPanel.tsx
+++ b/frontend/src/components/ProjectRightPanel.tsx
@@ -11,8 +11,18 @@
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useMatches } from "@tanstack/react-router";
 
-import { IDENTITY_PLACEMENT, MeshViewer, type Placement } from "@/components/MeshViewer";
-import { useApplyReconstructionTransform, useLatestReconstruction } from "@/lib/api";
+import { IDENTITY_PLACEMENT, MeshViewer, type Placement, type RobotReplay } from "@/components/MeshViewer";
+import {
+  useApplyReconstructionTransform,
+  useComparePolicies,
+  useLatestReconstruction,
+  useProjectState,
+} from "@/lib/api";
+
+// Two policies, two balls. Amber = greedy (heads straight at the goal, stalls
+// on obstacles); blue = the trained PPO (routes around them).
+const GREEDY_COLOR = 0xeec24a;
+const PPO_COLOR = 0x4a9eee;
 
 export function ProjectRightPanel() {
   const matches = useMatches();
@@ -24,12 +34,15 @@ export function ProjectRightPanel() {
       m.routeId.startsWith("/p/$projectId"),
   );
   const projectId = (projectMatch?.params as { projectId?: string } | undefined)?.projectId;
+  const onReplay = matches.some(
+    (m) => typeof m.routeId === "string" && m.routeId.endsWith("/replay"),
+  );
 
   if (!projectId) {
     return null;
   }
 
-  return <RightPaneForProject projectId={projectId} />;
+  return <RightPaneForProject projectId={projectId} onReplay={onReplay} />;
 }
 
 function isIdentity(p: Placement): boolean {
@@ -40,13 +53,47 @@ function isIdentity(p: Placement): boolean {
   );
 }
 
-function RightPaneForProject({ projectId }: { projectId: string }) {
+function RightPaneForProject({ projectId, onReplay }: { projectId: string; onReplay: boolean }) {
   const { data: recon } = useLatestReconstruction(projectId);
   const apply = useApplyReconstructionTransform(projectId);
 
   const [placement, setPlacement] = useState<Placement>(IDENTITY_PLACEMENT);
   const [meshBump, setMeshBump] = useState(0);
   const matrixRef = useRef<number[]>([]);
+
+  // On the Replay stage, race greedy vs the trained PPO on ONE sensible fixed
+  // track (the backend picks the most instructive seed — an obstacle in the
+  // way) and drive BOTH as balls through the textured mesh. The compare result
+  // carries the build's raw→sim transform so each path maps back onto the floor.
+  const { data: state } = useProjectState(projectId);
+  const canPPO = state?.train.complete ?? false;
+  const compare = useComparePolicies(projectId);
+
+  // Kick off the race once, when we land on Replay with a trained policy.
+  const comparedRef = useRef(false);
+  useEffect(() => {
+    comparedRef.current = false;
+  }, [projectId]);
+  useEffect(() => {
+    if (onReplay && canPPO && !comparedRef.current && !compare.isPending && !compare.data) {
+      comparedRef.current = true;
+      compare.mutate({});
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onReplay, canPPO]);
+
+  const cmp = compare.data;
+  const robots: RobotReplay[] =
+    onReplay && cmp && cmp.raw_to_sim
+      ? cmp.results.map((r) => ({
+          key: `${cmp.seed}-${r.policy}`,
+          color: r.policy === "ppo" ? PPO_COLOR : GREEDY_COLOR,
+          points: (r.trajectory ?? []).map((p) => ({ x: p.x, y: p.y })),
+          goal: r.goal ? { x: r.goal[0], y: r.goal[1] } : undefined,
+          rawToSim: cmp.raw_to_sim!,
+          floorZ: cmp.floor_z ?? 0,
+        }))
+      : [];
 
   const status = recon?.status;
   const reconId = recon?.id;
@@ -82,6 +129,7 @@ function RightPaneForProject({ projectId }: { projectId: string }) {
             onMatrix={(m) => {
               matrixRef.current = m;
             }}
+            robots={robots}
           />
         ) : (
           <div className="w-full h-full border border-dashed border-border/60 rounded-sm flex items-center justify-center text-center px-6 text-xs mono">
@@ -103,7 +151,36 @@ function RightPaneForProject({ projectId }: { projectId: string }) {
         )}
       </div>
 
-      {meshUrl && (
+      {meshUrl && onReplay && (
+        <div className="border border-border rounded-sm p-2.5 text-[11px] mono text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1">
+          {robots.length ? (
+            <>
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-2 h-2 rounded-full bg-[#eec24a]" /> greedy
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-2 h-2 rounded-full bg-[#4a9eee]" /> PPO
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-2 h-2 rounded-full bg-[#ff5a3c]" /> goal
+              </span>
+              <span className="text-muted-foreground/70">· same start → goal, on the floor</span>
+            </>
+          ) : compare.isPending ? (
+            <span className="animate-pulse">picking a sensible track and racing both policies…</span>
+          ) : !canPPO ? (
+            <span>train a PPO policy to race it against greedy here</span>
+          ) : compare.isError ? (
+            <span className="text-[var(--status-fail)]">
+              {String((compare.error as Error).message)}
+            </span>
+          ) : (
+            <span>preparing the head-to-head…</span>
+          )}
+        </div>
+      )}
+
+      {meshUrl && !onReplay && (
         <PlacementControls
           placement={placement}
           onChange={setPlacement}

--- a/frontend/src/components/TrajectoryViewer.tsx
+++ b/frontend/src/components/TrajectoryViewer.tsx
@@ -3,7 +3,15 @@
  *
  * Renders the build's bounds + spawn region as backdrop, then overlays
  * agent paths from one or more replay runs. Each run gets a color.
+ *
+ * Two modes:
+ *  - static ("Paths"): full trajectories drawn as lines.
+ *  - animate: a robot marker drives along each path over time, leaving a
+ *    growing trail, with play/pause + scrub controls. This is the
+ *    "watch the robot navigate the room" view.
  */
+import { useEffect, useRef, useState } from "react";
+
 import type { TrajectoryEpisode } from "@/lib/api";
 
 const COLORS: Record<string, string> = {
@@ -16,6 +24,7 @@ const POINT_COLORS = {
   start: "oklch(0.74 0.18 145)",
   goal: "oklch(0.65 0.22 25)",
   collision: "oklch(0.78 0.16 320)",
+  robot: "oklch(0.80 0.20 145)",
 };
 
 type Bounds = { min: number[]; max: number[] };
@@ -31,10 +40,12 @@ export function TrajectoryViewer({
   run,
   episodeIndex,
   height = 360,
+  animate = false,
 }: {
   run: TrajectoryRun;
   episodeIndex?: number;
   height?: number;
+  animate?: boolean;
 }) {
   const xmin = run.bounds.min[0] - 0.3;
   const xmax = run.bounds.max[0] + 0.3;
@@ -51,16 +62,53 @@ export function TrajectoryViewer({
 
   const episodes = episodeIndex !== undefined ? [run.episodes[episodeIndex]] : run.episodes;
   const color = COLORS[run.policy] ?? "oklch(0.72 0.18 230)";
+  const maxLen = Math.max(1, ...episodes.map((e) => e.trajectory?.length ?? 0));
+
+  // ---- animation state ----
+  const [frame, setFrame] = useState(0);
+  const [playing, setPlaying] = useState(true);
+  const rafRef = useRef<number | undefined>(undefined);
+  const accRef = useRef(0);
+  // a stable key for "this dataset" so we reset playback when it changes
+  const runKey = `${run.policy}:${run.episodes.length}:${episodeIndex ?? "all"}`;
+
+  useEffect(() => {
+    setFrame(0);
+    setPlaying(true);
+  }, [runKey]);
+
+  useEffect(() => {
+    if (!animate || !playing) return;
+    const STEPS_PER_SEC = 45;
+    let last = performance.now();
+    const tick = (now: number) => {
+      const dt = (now - last) / 1000;
+      last = now;
+      accRef.current += dt * STEPS_PER_SEC;
+      const advance = Math.floor(accRef.current);
+      if (advance >= 1) {
+        accRef.current -= advance;
+        setFrame((f) => (f + advance >= maxLen + 18 ? 0 : f + advance)); // pause ~0.4s at end, then loop
+      }
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [animate, playing, maxLen, runKey]);
 
   return (
-    <div
-      className="border border-border rounded-sm bg-card relative overflow-hidden"
-      style={{ height }}
-    >
-      <header className="absolute top-2 left-3 z-10">
+    <div className="border border-border rounded-sm bg-card relative overflow-hidden" style={{ height }}>
+      <header className="absolute top-2 left-3 z-10 flex items-center gap-2">
         <span className="mono text-[11px] uppercase tracking-wider text-muted-foreground">
           {run.policy} · {episodes.length}/{run.episodes.length} ep
         </span>
+        {animate && (
+          <span className="mono text-[10px] text-muted-foreground/70">
+            step {Math.min(frame, maxLen)}/{maxLen}
+          </span>
+        )}
       </header>
 
       <svg
@@ -69,11 +117,14 @@ export function TrajectoryViewer({
         className="w-full h-full"
         style={{ aspectRatio: aspect }}
       >
-        {/* grid */}
         <defs>
           <pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse">
             <path d="M 10 0 L 0 0 0 10" fill="none" stroke="#222" strokeWidth="0.15" />
           </pattern>
+          <radialGradient id="robotGlow">
+            <stop offset="0%" stopColor={POINT_COLORS.robot} stopOpacity="0.9" />
+            <stop offset="100%" stopColor={POINT_COLORS.robot} stopOpacity="0" />
+          </radialGradient>
         </defs>
         <rect width="100" height="100" fill="url(#grid)" />
 
@@ -100,13 +151,23 @@ export function TrajectoryViewer({
         {episodes.map((ep, i) => {
           if (!ep.trajectory || ep.trajectory.length < 2) return null;
           const points = ep.trajectory.map((p) => project(p.x, p.y));
-          const d = points.map((p, idx) => `${idx === 0 ? "M" : "L"}${p.x},${p.y}`).join(" ");
           const start = project(ep.spawn[0], ep.spawn[1]);
           const goal = project(ep.goal[0], ep.goal[1]);
-          const collisions = ep.trajectory.filter((p) => p.collision).map((p) => project(p.x, p.y));
+
+          // In animate mode, only draw the trail up to the current frame.
+          const upto = animate ? Math.min(frame, points.length) : points.length;
+          const trail = points.slice(0, Math.max(1, upto));
+          const d = trail.map((p, idx) => `${idx === 0 ? "M" : "L"}${p.x},${p.y}`).join(" ");
+          const head = points[Math.min(Math.max(upto - 1, 0), points.length - 1)];
+          const reachedGoal = ep.success && upto >= points.length;
+          const collisions = ep.trajectory
+            .slice(0, upto)
+            .filter((p) => p.collision)
+            .map((p) => project(p.x, p.y));
+
           return (
-            <g key={i} opacity={ep.success ? 1 : 0.55}>
-              <path d={d} fill="none" stroke={color} strokeWidth="0.45" strokeLinejoin="round" />
+            <g key={i} opacity={ep.success ? 1 : animate ? 0.85 : 0.55}>
+              <path d={d} fill="none" stroke={color} strokeWidth="0.45" strokeLinejoin="round" strokeLinecap="round" />
               <circle cx={start.x} cy={start.y} r="1.1" fill={POINT_COLORS.start} stroke="#000" strokeWidth="0.15" />
               <g transform={`translate(${goal.x},${goal.y})`}>
                 <polygon
@@ -114,19 +175,52 @@ export function TrajectoryViewer({
                   fill={POINT_COLORS.goal}
                   stroke="#000"
                   strokeWidth="0.15"
+                  opacity={reachedGoal ? 1 : 0.85}
                 />
               </g>
               {collisions.map((c, j) => (
                 <circle key={j} cx={c.x} cy={c.y} r="0.4" fill={POINT_COLORS.collision} />
               ))}
+              {/* the robot marker (animate mode) */}
+              {animate && head && (
+                <g transform={`translate(${head.x},${head.y})`}>
+                  <circle r="2.6" fill="url(#robotGlow)" />
+                  <circle r="1.25" fill={POINT_COLORS.robot} stroke="#000" strokeWidth="0.2" />
+                </g>
+              )}
             </g>
           );
         })}
       </svg>
 
-      <div className="absolute bottom-2 right-3 mono text-[10px] text-muted-foreground/70">
-        x: [{xmin.toFixed(1)}, {xmax.toFixed(1)}] · y: [{ymin.toFixed(1)}, {ymax.toFixed(1)}]
-      </div>
+      {/* playback controls */}
+      {animate && (
+        <div className="absolute bottom-2 left-3 right-3 z-10 flex items-center gap-2">
+          <button
+            onClick={() => setPlaying((p) => !p)}
+            className="px-2 py-0.5 rounded-sm border border-border bg-card/80 mono text-[10px] hover:bg-accent"
+          >
+            {playing ? "❚❚" : "▶"}
+          </button>
+          <input
+            type="range"
+            min={0}
+            max={maxLen}
+            value={Math.min(frame, maxLen)}
+            onChange={(e) => {
+              setPlaying(false);
+              setFrame(Number(e.target.value));
+            }}
+            className="flex-1 accent-[var(--primary)] h-1"
+          />
+        </div>
+      )}
+
+      {!animate && (
+        <div className="absolute bottom-2 right-3 mono text-[10px] text-muted-foreground/70">
+          x: [{xmin.toFixed(1)}, {xmax.toFixed(1)}] · y: [{ymin.toFixed(1)}, {ymax.toFixed(1)}]
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -424,12 +424,21 @@ export const useTrain = (projectId: string) => {
   });
 };
 
-export type TrajectoryPoint = { step: number; x: number; y: number; collision: boolean };
+export type TrajectoryPoint = {
+  step: number;
+  x: number;
+  y: number;
+  collision: boolean;
+  near?: boolean;
+};
 export type TrajectoryEpisode = ReplayEpisode & {
   failure_class: "success" | "timeout" | "stuck" | "collided" | "near-miss";
   spawn: number[];
   goal: number[];
   trajectory: TrajectoryPoint[] | null;
+  avoided?: number;
+  avoid_points?: { x: number; y: number }[];
+  collisions?: number;
 };
 export type TrajectoryReplayResponse = Omit<ReplayResponse, "episodes"> & {
   bounds: { min: number[]; max: number[] };
@@ -463,6 +472,33 @@ export const useStartReplay = (projectId: string) => {
     onSuccess: () => qc.invalidateQueries({ queryKey: ["runs", projectId] }),
   });
 };
+
+export type CompareEpisode = {
+  policy: string;
+  steps: number;
+  success: boolean;
+  distance: number;
+  collisions: number;
+  avoided: number;
+  spawn: number[];
+  goal: number[];
+  trajectory: TrajectoryPoint[];
+};
+export type CompareResponse = {
+  seed: number;
+  bounds: { min: number[]; max: number[] };
+  spawn_region: { xmin: number; xmax: number; ymin: number; ymax: number };
+  results: CompareEpisode[];
+  raw_to_sim?: number[][] | null;
+  floor_z?: number;
+};
+
+// Run greedy + the trained PPO on the SAME start→goal, head-to-head.
+export const useComparePolicies = (projectId: string) =>
+  useMutation({
+    mutationFn: (body: { seed?: number; max_steps?: number }) =>
+      send<CompareResponse>(`/api/projects/${projectId}/compare`, "POST", body),
+  });
 
 export const useRun = (projectId: string, runId: string | null | undefined) => {
   const qc = useQueryClient();

--- a/frontend/src/routes/p.$projectId.replay.tsx
+++ b/frontend/src/routes/p.$projectId.replay.tsx
@@ -2,10 +2,12 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Lock } from "lucide-react";
 import { useState } from "react";
 
+import { CompareViewer } from "@/components/CompareViewer";
 import { ProjectSceneLayout } from "@/components/ProjectSceneLayout";
 import { StatusDot } from "@/components/StatusDot";
 import { TrajectoryViewer, type TrajectoryRun } from "@/components/TrajectoryViewer";
 import {
+  useComparePolicies,
   useProjectRuns,
   useProjectState,
   useRun,
@@ -24,9 +26,11 @@ function ReplayScreen() {
   const navigate = useNavigate();
   const { data: state } = useProjectState(projectId);
   const startReplay = useStartReplay(projectId);
+  const compare = useComparePolicies(projectId);
   const [runId, setRunId] = useState<string | null>(null);
   const [policy, setPolicy] = useState<PolicyName>("greedy");
   const [episodeIdx, setEpisodeIdx] = useState<number | undefined>(undefined);
+  const [viewMode, setViewMode] = useState<"animate" | "paths">("animate");
 
   const canReplay = state?.replay.complete ?? false;
   const canPPO = state?.train.complete ?? false;
@@ -37,10 +41,14 @@ function ReplayScreen() {
   const ready = live?.status === "ok";
   const { data: traj } = useRunTrajectories(projectId, runId, ready);
 
-  const start = async (p: PolicyName) => {
+  // One run = one robot, one random start → random goal. A fresh random seed
+  // every press, so each play spawns a new start/goal. `count > 1` is the
+  // benchmark mode (several episodes at once).
+  const start = async (p: PolicyName, count = 1) => {
     setPolicy(p);
     setEpisodeIdx(undefined);
-    const r = await startReplay.mutateAsync({ policy: p, episodes: 5, max_steps: 300, seed: 0 });
+    const seed = Math.floor(Math.random() * 1_000_000);
+    const r = await startReplay.mutateAsync({ policy: p, episodes: count, max_steps: 300, seed });
     setRunId(r.id);
   };
 
@@ -81,18 +89,19 @@ function ReplayScreen() {
   return (
     <ProjectSceneLayout projectId={projectId} current="replay">
       <header>
-        <h1 className="text-2xl">Replay</h1>
+        <h1 className="text-2xl">Navigate</h1>
         <p className="text-sm text-muted-foreground mt-1.5">
-          Random / greedy baselines + the trained policy.
+          One robot, a random start → a random goal. Press again for a new
+          start/goal. Watch it route around obstacles.
         </p>
       </header>
 
       <div className="mt-6 flex flex-col gap-2">
-        {(["random", "greedy", "ppo"] as PolicyName[]).map((p) => (
+        {(["ppo", "greedy", "random"] as PolicyName[]).map((p) => (
           <button
             key={p}
             disabled={startReplay.isPending || (p === "ppo" && !canPPO) || live?.status === "running"}
-            onClick={() => start(p)}
+            onClick={() => start(p, 1)}
             title={p === "ppo" && !canPPO ? "Train a PPO policy first" : undefined}
             className={
               "text-left px-4 py-2 rounded-sm border-2 text-sm transition-colors " +
@@ -102,10 +111,51 @@ function ReplayScreen() {
               (p === "ppo" && !canPPO ? " opacity-40 cursor-not-allowed" : "")
             }
           >
-            Run {p} (5 episodes)
+            {p === "ppo" ? "▶ Navigate (trained policy)" : `▶ Navigate (${p} baseline)`}
+            <span className="text-muted-foreground"> · random start → goal</span>
           </button>
         ))}
+        <button
+          disabled={startReplay.isPending || live?.status === "running"}
+          onClick={() => start(policy, 5)}
+          className="text-left px-4 py-1.5 rounded-sm border border-dashed border-border text-xs text-muted-foreground hover:bg-accent mt-1"
+        >
+          Benchmark · 5 random episodes at once
+        </button>
       </div>
+
+      <section className="mt-6 border border-border rounded-sm p-3">
+        <div className="flex items-center justify-between gap-2">
+          <div>
+            <h2 className="text-sm">Greedy vs PPO — same start &amp; goal</h2>
+            <p className="text-[11px] text-muted-foreground mt-0.5">
+              Both policies run the identical config. Where an obstacle is in
+              the way, greedy stalls and PPO routes around it.
+            </p>
+          </div>
+          <div className="flex gap-1.5 shrink-0">
+            <button
+              disabled={!canPPO || compare.isPending}
+              onClick={() => compare.mutate({})}
+              title={!canPPO ? "Train a PPO policy first" : undefined}
+              className={
+                "px-3 py-1.5 rounded-sm text-xs whitespace-nowrap " +
+                (canPPO
+                  ? "bg-primary text-primary-foreground hover:opacity-90"
+                  : "border border-border opacity-40 cursor-not-allowed")
+              }
+            >
+              {compare.isPending ? "Racing…" : compare.data ? "↻ New config" : "⚔ Compare"}
+            </button>
+          </div>
+        </div>
+        {compare.error && (
+          <p className="mt-2 text-[11px] text-[var(--status-fail)] mono">
+            {String((compare.error as Error).message)}
+          </p>
+        )}
+        {compare.data && <div className="mt-3"><CompareViewer data={compare.data} height={280} /></div>}
+      </section>
 
       {startReplay.error && (
         <p className="mt-3 text-sm text-[var(--status-fail)] mono">
@@ -129,7 +179,7 @@ function ReplayScreen() {
               }
               label={
                 live.status === "ok"
-                  ? `${live.successes}/${live.n_episodes ?? live.episodes ?? 5}`
+                  ? `${live.successes}/${live.episodes ?? 5}`
                   : live.status
               }
             />
@@ -143,23 +193,105 @@ function ReplayScreen() {
 
           {trajRun && (
             <>
-              <TrajectoryViewer run={trajRun} episodeIndex={episodeIdx} height={220} />
-              <div className="flex gap-1.5 flex-wrap">
-                {trajRun.episodes.map((e, i) => (
+              <div className="flex gap-1">
+                {(["animate", "paths"] as const).map((m) => (
                   <button
-                    key={i}
-                    onClick={() => setEpisodeIdx(episodeIdx === i ? undefined : i)}
+                    key={m}
+                    onClick={() => setViewMode(m)}
                     className={
-                      "px-2 py-1 rounded-sm mono text-[10px] " +
-                      (episodeIdx === i
+                      "px-3 py-1 rounded-sm mono text-[10px] uppercase tracking-wider " +
+                      (viewMode === m
                         ? "bg-foreground text-background"
                         : "border border-border hover:bg-accent")
                     }
                   >
-                    ep{i + 1} {e.success ? "✓" : "✗"} {e.failure_class}
+                    {m === "animate" ? "▶ Animate" : "Paths"}
                   </button>
                 ))}
               </div>
+              <TrajectoryViewer
+                run={trajRun}
+                episodeIndex={episodeIdx}
+                height={260}
+                animate={viewMode === "animate"}
+              />
+              {(() => {
+                const eps = trajRun.episodes;
+                const single = eps.length === 1;
+                let col = 0;
+                let steps = 0;
+                let succ = 0;
+                let avoided = 0;
+                for (const e of eps) {
+                  const t = e.trajectory ?? [];
+                  steps += t.length;
+                  col += e.collisions ?? t.filter((p) => p.collision).length;
+                  if (e.success) succ += 1;
+                  avoided += e.avoided ?? 0;
+                }
+                const collRate = steps ? (100 * col) / steps : 0;
+                const avgSteps = eps.length ? Math.round(steps / eps.length) : 0;
+
+                if (single) {
+                  const e = eps[0];
+                  const n = e.trajectory?.length ?? avgSteps;
+                  const shown = Math.min(avoided, 6);
+                  return (
+                    <div className="space-y-1.5">
+                      <div className="mono text-[12px]">
+                        {e.success ? (
+                          <span className="text-[var(--status-ok)]">✓ reached the goal in {n} steps</span>
+                        ) : (
+                          <span className="text-[var(--status-fail)]">✗ did not reach the goal ({n} steps)</span>
+                        )}
+                      </div>
+                      <div className="flex flex-col gap-0.5 mono text-[11px] text-muted-foreground border-l-2 border-border pl-2">
+                        {avoided > 0 ? (
+                          <>
+                            {Array.from({ length: shown }).map((_, i) => (
+                              <span key={i}>🛡️ avoided an obstacle</span>
+                            ))}
+                            {avoided > shown && <span>… and {avoided - shown} more</span>}
+                          </>
+                        ) : (
+                          <span>· clear path — no obstacles to route around</span>
+                        )}
+                        {col > 0 && (
+                          <span className="text-[var(--status-fail)]">
+                            ⚠ bumped an obstacle on {col} step{col > 1 ? "s" : ""}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  );
+                }
+                return (
+                  <div className="flex gap-4 mono text-[11px] text-muted-foreground">
+                    <span>success <span className="text-foreground">{succ}/{eps.length}</span></span>
+                    <span>collision rate <span className="text-foreground">{collRate.toFixed(1)}%</span></span>
+                    <span>avoided <span className="text-foreground">{avoided}</span></span>
+                    <span>avg steps <span className="text-foreground">{avgSteps}</span></span>
+                  </div>
+                );
+              })()}
+              {trajRun.episodes.length > 1 && (
+                <div className="flex gap-1.5 flex-wrap">
+                  {trajRun.episodes.map((e, i) => (
+                    <button
+                      key={i}
+                      onClick={() => setEpisodeIdx(episodeIdx === i ? undefined : i)}
+                      className={
+                        "px-2 py-1 rounded-sm mono text-[10px] " +
+                        (episodeIdx === i
+                          ? "bg-foreground text-background"
+                          : "border border-border hover:bg-accent")
+                      }
+                    >
+                      ep{i + 1} {e.success ? "✓" : "✗"} {e.failure_class}
+                    </button>
+                  ))}
+                </div>
+              )}
             </>
           )}
         </section>

--- a/rl_env/rl_env/build.py
+++ b/rl_env/rl_env/build.py
@@ -60,6 +60,9 @@ class BuildArtifacts:
     floor_z: float
     spawn_region: tuple[float, float, float, float]  # xmin, xmax, ymin, ymax
     materials: dict[str, dict] = field(default_factory=dict)
+    # 4x4 raw-mesh -> sim/MJCF transform (rotate up-axis, center+ground, scale).
+    # Lets viewers map sim-frame trajectories back onto the raw textured mesh.
+    raw_to_sim: np.ndarray | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -68,11 +71,36 @@ class BuildArtifacts:
 
 
 def _detect_up_axis(mesh: trimesh.Trimesh) -> str:
-    """Heuristic: the up axis is whichever has the largest vertical-extent / horizontal-extent ratio.
+    """Find the vertical axis of a room-like mesh.
 
-    For room-like meshes this is unreliable, so callers should override when known.
-    Falls back to 'y' (most photo-depth pipelines).
+    A real floor (and usually a ceiling) is a dense, flat plane sitting at one
+    extreme of the vertical axis; walls are not. So the vertical axis is the one
+    whose extreme planes hold the largest fraction of vertices. This is far more
+    reliable than comparing bounding-box extents (a room is often wider/longer
+    than it is tall, which fooled the old extent heuristic into picking a
+    horizontal axis as "up").
+
+    Falls back to the extent heuristic when the floor signal is weak/ambiguous
+    (e.g. a closed synthetic box with uniform vertex density).
     """
+    v = np.asarray(mesh.vertices)
+
+    def floor_conc(ax: int) -> float:
+        lo, hi = float(v[:, ax].min()), float(v[:, ax].max())
+        span = hi - lo
+        if span < 1e-6:
+            return 0.0
+        near_lo = float(np.mean(v[:, ax] < lo + 0.08 * span))
+        near_hi = float(np.mean(v[:, ax] > hi - 0.08 * span))
+        return max(near_lo, near_hi)
+
+    cy, cz = floor_conc(1), floor_conc(2)
+    # One axis clearly dominating the other is the signal — partial scans may
+    # only put ~15-20% of vertices in the floor slab, so judge by ratio, not by
+    # an absolute cutoff.
+    if max(cy, cz) >= 0.10 and max(cy, cz) > 1.5 * min(cy, cz):
+        return "y" if cy > cz else "z"
+
     extents = mesh.extents
     if extents[2] > extents[1] * 1.2 and extents[2] > extents[0] * 0.5:
         return "z"
@@ -90,25 +118,41 @@ def _to_z_up(mesh: trimesh.Trimesh, up_axis: str) -> trimesh.Trimesh:
     raise ValueError(f"unknown up axis: {up_axis}")
 
 
-def preprocess(mesh: trimesh.Trimesh, cfg: BuildConfig) -> tuple[trimesh.Trimesh, float]:
-    """Return (mesh in MuJoCo Z-up coords, floor_z)."""
+def preprocess(mesh: trimesh.Trimesh, cfg: BuildConfig) -> tuple[trimesh.Trimesh, float, np.ndarray]:
+    """Return (mesh in MuJoCo Z-up coords, floor_z, raw_to_sim 4x4).
+
+    raw_to_sim maps a point in the original mesh's coordinates to the
+    sim/MJCF frame, composed as scale @ translate @ rotate.
+    """
     up = cfg.up_axis if cfg.up_axis != "auto" else _detect_up_axis(mesh)
-    mesh = _to_z_up(mesh, up)
+    if up == "y":
+        R = trimesh.transformations.rotation_matrix(np.pi / 2, [1, 0, 0])
+    elif up == "z":
+        R = np.eye(4)
+    else:
+        raise ValueError(f"unknown up axis: {up}")
+    mesh = mesh.copy()
+    mesh.apply_transform(R)
 
     mins = mesh.bounds[0]
     maxs = mesh.bounds[1]
     center_xy = (mins[:2] + maxs[:2]) / 2
-    mesh.apply_translation((-center_xy[0], -center_xy[1], -mins[2]))
+    tvec = np.array([-center_xy[0], -center_xy[1], -mins[2]], dtype=float)
+    Tm = trimesh.transformations.translation_matrix(tvec)
+    mesh.apply_translation(tvec)
 
+    Sm = np.eye(4)
     if cfg.target_diagonal_m is not None:
         ext = mesh.extents
         diag_xy = float(np.hypot(ext[0], ext[1]))
         if diag_xy > 1e-6:
             scale = cfg.target_diagonal_m / diag_xy
+            Sm = trimesh.transformations.scale_matrix(scale)
             mesh.apply_scale(scale)
 
     floor_z = float(mesh.bounds[0][2])
-    return mesh, floor_z
+    raw_to_sim = Sm @ Tm @ R  # apply R first, then T, then S
+    return mesh, floor_z, raw_to_sim
 
 
 # ---------------------------------------------------------------------------
@@ -116,23 +160,131 @@ def preprocess(mesh: trimesh.Trimesh, cfg: BuildConfig) -> tuple[trimesh.Trimesh
 # ---------------------------------------------------------------------------
 
 
+# A reconstruction mesh can be millions of faces; coarse collision geometry
+# doesn't need that, and the heavy ops below choke on it. Decimate first.
+_COLLISION_MAX_FACES = 120_000
+
+
+def _decimate_for_collision(mesh: trimesh.Trimesh, max_faces: int = _COLLISION_MAX_FACES) -> trimesh.Trimesh:
+    """Best-effort reduce face count before decomposition. If no decimation
+    backend is available, return the mesh unchanged — the component fallback
+    below is memory-safe either way."""
+    if len(mesh.faces) <= max_faces:
+        return mesh
+    try:
+        out = mesh.simplify_quadric_decimation(face_count=max_faces)
+        if out is not None and len(out.faces) > 0:
+            return out
+    except Exception:
+        pass
+    return mesh
+
+
+def _largest_components(mesh: trimesh.Trimesh, k: int) -> list[trimesh.Trimesh]:
+    """Up to `k` largest connected components, materialised one at a time.
+
+    Avoids `mesh.split()` — which builds a full Trimesh for *every* component,
+    OOMing on a back-projected mesh with thousands of tiny noise islands. We
+    label components cheaply (face adjacency) and only copy out the biggest few.
+    """
+    nf = len(mesh.faces)
+    if nf == 0:
+        return [mesh]
+    try:
+        from trimesh.graph import connected_components
+
+        comps = connected_components(mesh.face_adjacency, min_len=1, nodes=np.arange(nf))
+    except Exception:
+        return [mesh]
+    comps = sorted(comps, key=len, reverse=True)[: max(k, 1)]
+    out: list[trimesh.Trimesh] = []
+    for fi in comps:
+        try:
+            out.append(mesh.submesh([fi], append=True, repair=False))
+        except Exception:
+            pass
+    return out or [mesh]
+
+
+def _real_floor_z(mesh: trimesh.Trimesh) -> float:
+    """The visible floor height: the densest z-slab in the lower 40% of the
+    height range. Phone scans have noise *below* the real floor, so the mesh
+    minimum sits under the surface the robot should roll on."""
+    zs = np.asarray(mesh.vertices)[:, 2]
+    hist, edges = np.histogram(zs, bins=80)
+    i = int(np.argmax(hist[: max(1, int(80 * 0.4))]))
+    return float((edges[i] + edges[i + 1]) / 2)
+
+
+def _occupancy_columns(
+    mesh: trimesh.Trimesh,
+    floor_z: float,
+    cell: float = 0.17,
+    band_lo: float = 0.14,
+    band_hi: float = 1.4,
+    max_boxes: int = 700,
+) -> list[tuple[float, float, float, float, float, float]]:
+    """2.5D costmap collision: one box column per XY cell that contains mesh
+    points in the obstacle band above the floor (walls, furniture).
+
+    Convex hulls of a curved scan shell each wrap huge swaths of *free* space —
+    the agent ends up "in collision" everywhere and lidar sees phantom walls.
+    Box columns hug the actual geometry instead. Returns (cx, cy, hx, hy, z0, z1).
+    """
+    v = np.asarray(mesh.vertices)
+    zs = v[:, 2]
+    pts = v[(zs > floor_z + band_lo) & (zs < floor_z + band_hi)]
+    if not len(pts):
+        return []
+    while True:
+        origin = pts[:, :2].min(axis=0)
+        ij = np.floor((pts[:, :2] - origin) / cell).astype(int)
+        from collections import defaultdict
+
+        zmax: dict[tuple[int, int], float] = defaultdict(float)
+        count: dict[tuple[int, int], int] = defaultdict(int)
+        for (i, j), z in zip(map(tuple, ij), pts[:, 2]):
+            count[(i, j)] += 1
+            zmax[(i, j)] = max(zmax[(i, j)], z - floor_z)
+        thr = max(4, int(np.percentile(np.array(list(count.values())), 30) * 0.4))
+        cells = [c for c, n in count.items() if n >= thr]
+        if len(cells) <= max_boxes:
+            break
+        cell *= 1.4  # too fine for this scan — coarsen and retry
+    half = cell * 0.55  # slight overlap so diagonal gaps don't leak
+    out = []
+    for c in cells:
+        h = max(0.12, float(zmax[c]) / 2)
+        out.append((
+            float(origin[0] + (c[0] + 0.5) * cell),
+            float(origin[1] + (c[1] + 0.5) * cell),
+            half, half,
+            floor_z, floor_z + 2 * h,
+        ))
+    return out
+
+
 def decompose(mesh: trimesh.Trimesh, cfg: BuildConfig) -> list[trimesh.Trimesh]:
     """Return a list of convex hull meshes covering `mesh`.
 
     Strategy:
-      1. If trimesh has a working VHACD/CoACD backend, use it.
-      2. Else split into connected components and take convex hull of each.
-      3. If that yields too few hulls (e.g. one big merged mesh), fall back to
-         a single convex hull of the entire scene — coarse but always works.
+      1. Decimate huge meshes (coarse collision geometry needs few faces).
+      2. If trimesh has a working VHACD/CoACD backend, use it.
+      3. Else take convex hulls of the largest connected components.
+      4. If that yields nothing, a single convex hull of the whole scene.
 
     The MVP intentionally accepts coarse collision geometry; tightening this
     is a known follow-up (PRD: "balance collision fidelity against simulation
     speed", Key technical challenge #1).
     """
-    if cfg.decompose:
+    work = _decimate_for_collision(mesh)
+
+    # Only attempt VHACD if the mesh is a sane size — it's slow/heavy on a
+    # multi-million-face mesh, and the component fallback is always safe.
+    if cfg.decompose and len(work.faces) <= _COLLISION_MAX_FACES * 4:
         try:
             hulls = trimesh.decomposition.convex_decomposition(
-                mesh, maxNumVerticesPerCH=64, resolution=100_000
+                work, maxNumVerticesPerCH=64, resolution=100_000
             )
             if hulls:
                 hulls = [h for h in hulls if h.is_volume and h.volume > 1e-6]
@@ -141,12 +293,8 @@ def decompose(mesh: trimesh.Trimesh, cfg: BuildConfig) -> list[trimesh.Trimesh]:
         except Exception:
             pass
 
-    components = mesh.split(only_watertight=False)
-    if len(components) == 0:
-        components = [mesh]
-
     hulls: list[trimesh.Trimesh] = []
-    for c in components[: cfg.max_hulls]:
+    for c in _largest_components(work, cfg.max_hulls):
         try:
             h = c.convex_hull
             if h.is_volume and h.volume > 1e-6:
@@ -155,7 +303,10 @@ def decompose(mesh: trimesh.Trimesh, cfg: BuildConfig) -> list[trimesh.Trimesh]:
             continue
 
     if not hulls:
-        hulls = [mesh.convex_hull]
+        try:
+            hulls = [work.convex_hull]
+        except Exception:
+            hulls = [mesh.convex_hull]
 
     return hulls
 
@@ -226,6 +377,7 @@ def write_mjcf(
     enclose: bool = True,
     wall_margin: float = 0.25,
     wall_thickness: float = 0.08,
+    boxes: list[tuple[float, float, float, float, float, float]] | None = None,
 ) -> Path:
     mesh_dir = out_dir / "meshes"
     mesh_dir.mkdir(parents=True, exist_ok=True)
@@ -330,6 +482,24 @@ def write_mjcf(
             mesh=Path(fname).stem,
             rgba=" ".join(f"{v:.3f}" for v in mat["rgba"]),
             friction=" ".join(f"{v:.4f}" for v in mat["friction"]),
+        )
+    # Occupancy-column collision (scan meshes). Named hull_box_* so NavEnv
+    # counts touches as scene collisions and lidar sees them (env matches the
+    # `hull_` prefix).
+    for i, (cx, cy, hx, hy, z0, z1) in enumerate(boxes or []):
+        ET.SubElement(
+            scene_body,
+            "geom",
+            name=f"hull_box_{i:04d}",
+            type="box",
+            size=f"{hx:.4f} {hy:.4f} {(z1 - z0) / 2:.4f}",
+            pos=f"{cx:.4f} {cy:.4f} {(z0 + z1) / 2:.4f}",
+            contype="1",
+            conaffinity="1",
+            condim="3",
+            group="1",
+            rgba="0.78 0.78 0.78 1",
+            friction="1.0 0.005 0.0001",
         )
 
     # Invisible boundary walls — enclose the navigable footprint so the agent
@@ -450,16 +620,26 @@ def build_environment(cfg: BuildConfig) -> BuildArtifacts:
     if isinstance(raw, trimesh.Scene):
         raw = trimesh.util.concatenate(tuple(raw.geometry.values()))
 
-    mesh, floor_z = preprocess(raw, cfg)
+    mesh, floor_z, raw_to_sim = preprocess(raw, cfg)
     bounds = mesh.bounds
     spawn_region = _spawn_region_from_bounds(bounds)
 
-    hulls = decompose(mesh, cfg)
-    classes = [classify_hull(h, bounds) for h in hulls]
-
-    keep_idx = [i for i, c in enumerate(classes) if c != "floor"]
-    hulls = [hulls[i] for i in keep_idx]
-    classes = [classes[i] for i in keep_idx]
+    # Phone scans (dense, noisy, partial): ground the nav world at the REAL
+    # floor and collide against 2.5D occupancy columns. Convex hulls of a
+    # curved shell wrap free space and leave the agent "in collision"
+    # everywhere; box columns hug the actual walls/furniture.
+    is_scan = len(mesh.vertices) >= 20_000
+    boxes: list[tuple[float, float, float, float, float, float]] = []
+    if is_scan:
+        floor_z = _real_floor_z(mesh)
+        boxes = _occupancy_columns(mesh, floor_z)
+        hulls, classes = [], []
+    else:
+        hulls = decompose(mesh, cfg)
+        classes = [classify_hull(h, bounds) for h in hulls]
+        keep_idx = [i for i, c in enumerate(classes) if c != "floor"]
+        hulls = [hulls[i] for i in keep_idx]
+        classes = [classes[i] for i in keep_idx]
 
     mjcf_path = write_mjcf(
         hulls=hulls,
@@ -471,6 +651,7 @@ def build_environment(cfg: BuildConfig) -> BuildArtifacts:
         enclose=cfg.enclose,
         wall_margin=cfg.wall_margin,
         wall_thickness=cfg.wall_thickness,
+        boxes=boxes,
     )
 
     materials = {f"hull_{i:04d}": MATERIAL_TABLE[c] for i, c in enumerate(classes)}
@@ -480,16 +661,18 @@ def build_environment(cfg: BuildConfig) -> BuildArtifacts:
         "bounds_max": bounds[1].tolist(),
         "floor_z": float(floor_z),
         "spawn_region": list(spawn_region),
-        "n_hulls": len(hulls),
+        "n_hulls": len(hulls) + len(boxes),
+        "raw_to_sim": raw_to_sim.tolist(),
     }
     (out_dir / "metadata.json").write_text(json.dumps(metadata, indent=2))
 
     return BuildArtifacts(
         mjcf_path=mjcf_path,
         mesh_dir=out_dir / "meshes",
-        n_hulls=len(hulls),
+        n_hulls=len(hulls) + len(boxes),
         bounds=bounds,
         floor_z=floor_z,
         spawn_region=spawn_region,
         materials=materials,
+        raw_to_sim=raw_to_sim,
     )

--- a/rl_env/rl_env/env.py
+++ b/rl_env/rl_env/env.py
@@ -34,6 +34,14 @@ class TaskConfig:
     min_start_goal_dist: float = 1.5
     max_start_goal_dist: float | None = None
     seed: int | None = None
+    fixed_spawn: tuple[float, float] | None = None
+    """Exact start (x, y). Overrides spawn_region sampling for the agent."""
+    fixed_goal: tuple[float, float] | None = None
+    """Exact goal (x, y). Overrides spawn_region sampling for the goal."""
+    spawn_cells: list[tuple[float, float]] | None = None
+    """Walkable floor cells (x, y). When set, start/goal are sampled from these
+    instead of the spawn_region box — keeps episodes on the scanned floor of a
+    partial reconstruction rather than the empty corners of its bounding box."""
 
 
 class NavEnv(gym.Env):
@@ -136,16 +144,40 @@ class NavEnv(gym.Env):
         min_dist = float(max(0.0, self.task.min_start_goal_dist))
         max_dist = self.task.max_start_goal_dist
 
-        agent = self.np_random.uniform([xmin, ymin], [xmax, ymax])
-        goal = self.np_random.uniform([xmin, ymin], [xmax, ymax])
-        for _ in range(64):
-            agent = self.np_random.uniform([xmin, ymin], [xmax, ymax])
-            goal = self.np_random.uniform([xmin, ymin], [xmax, ymax])
-            dist = float(np.linalg.norm(agent - goal))
-            if dist < min_dist:
-                continue
-            if max_dist is not None and dist > max_dist:
-                continue
+        cells = (
+            np.asarray(self.task.spawn_cells, dtype=float)
+            if self.task.spawn_cells is not None and len(self.task.spawn_cells) >= 2
+            else None
+        )
+
+        def _sample() -> np.ndarray:
+            if cells is not None:
+                c = cells[self.np_random.integers(len(cells))]
+                return c + self.np_random.uniform(-0.06, 0.06, size=2)
+            return self.np_random.uniform([xmin, ymin], [xmax, ymax])
+
+        if self.task.fixed_spawn is not None and self.task.fixed_goal is not None:
+            agent = np.asarray(self.task.fixed_spawn, dtype=float)
+            goal = np.asarray(self.task.fixed_goal, dtype=float)
+        else:
+            agent = _sample()
+            goal = _sample()
+            for _ in range(64):
+                agent = (
+                    np.asarray(self.task.fixed_spawn, dtype=float)
+                    if self.task.fixed_spawn is not None
+                    else _sample()
+                )
+                goal = (
+                    np.asarray(self.task.fixed_goal, dtype=float)
+                    if self.task.fixed_goal is not None
+                    else _sample()
+                )
+                dist = float(np.linalg.norm(agent - goal))
+                if dist < min_dist:
+                    continue
+                if max_dist is not None and dist > max_dist:
+                    continue
                 break
 
         self.data.qpos[self._agent_x_qpos] = agent[0]


### PR DESCRIPTION
## What this does

Turns the Replay stage into the software-fair demo: after scanning a room, two policies (amber = greedy baseline, blue = trained PPO) race **corner-to-corner through the actual scanned room** as balls rolling on the floor of the textured mesh, routing around furniture.

### RL / replay
- **Greedy-vs-PPO compare** (`POST /projects/{id}/compare`): both policies run the identical start→goal; returns both trajectories + the build's `raw_to_sim` transform so the 3D viewer maps paths onto the textured mesh. 2D overlay via new `CompareViewer`; the right-panel MeshViewer renders multi-robot replays (translucent "dollhouse" while racing, true goal marker, smooth docking at the goal).
- **Scanned-floor footprint**: partial scans don't fill their bounding box, so box-corner spawns put the robot "outside the room". We grid the mesh's floor band, **physics-probe each cell in the MJCF** (agent placed there, collision checked), keep the largest connected free region, and pick the farthest-apart pair — a deterministic, sensible corner-to-corner track. Replay episodes and **training spawns** both draw from these cells.
- **2.5D occupancy-column collision** for scan meshes: convex hulls of a curved scan shell wrap huge swaths of free space (the agent was "in collision" standing still on open floor, lidar saw phantom walls). One box column per occupied floor cell hugs the real walls/furniture instead. Synthetic/small meshes keep the hull path.
- **Real-floor grounding**: floor plane / agent / goal sit at the densest vertex slab (the floor you see), not the noisy mesh minimum. Up-axis detection now uses floor-slab concentration instead of bbox extents (fixes Y-up scans detected as Z-up → robot under the map).
- `TaskConfig` gains `fixed_spawn` / `fixed_goal` / `spawn_cells`; fixes an unreachable `break` in `reset()` that ignored `min_start_goal_dist`.
- Obstacle-avoidance events (lidar proximity escaped without contact) + collision stats surfaced in the replay UI.

### Host mode (run without docker)
- reconstruct/validate/build/train/replay run as in-process FastAPI `BackgroundTasks` (no Inngest needed locally).
- SQLite works out of the box (portable `JSON` columns aliased as `JSONB`, `check_same_thread` connect arg). Postgres/docker path unchanged in behavior but **reviewers note**: job dispatch is now in-process rather than Inngest events — flag if the worker-container split matters for deploys.
- Includes the OOM-safe validation `checks.py` from bbd4ef1.

## How to try it
1. Backend: `uvicorn src.app:app` (SQLite fallback works), frontend: `npm run dev`.
2. Upload a clip → Reconstruct (pi3/mapanything recommended) → Build → Train (~2 min, 300k steps) → Replay: the two balls race automatically in the 3D panel.

## Numbers from the demo room
Open scan: both succeed, 0 collisions (PPO 128 steps vs greedy 148). Cluttered room: greedy times out grinding the obstacle (300 steps, 248 collisions) while PPO routes around it (115 steps, 0 collisions).